### PR TITLE
Feat/#35 Custom Pop up View, Toast Message 구현

### DIFF
--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0EA432E529A136A700C4D47F /* WithPeopleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA432E429A136A700C4D47F /* WithPeopleView.swift */; };
 		0EA432E729A13EBE00C4D47F /* RelatedUrlButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA432E629A13EBE00C4D47F /* RelatedUrlButton.swift */; };
 		0EAD37DA29E6F13600C3EA38 /* BookmarkVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAD37D929E6F13600C3EA38 /* BookmarkVM.swift */; };
+		0EB8D81229FF8C0E00E79BA4 /* PopUpType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB8D81129FF8C0E00E79BA4 /* PopUpType.swift */; };
 		0EFE7C3629AA46CA0051E72D /* ReetBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFE7C3529AA46CA0051E72D /* ReetBottomSheet.swift */; };
 		0EFE7C3829AA504F0051E72D /* BookmarkBottomSheetVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFE7C3729AA504F0051E72D /* BookmarkBottomSheetVC.swift */; };
 		0EFE7C3A29AA60880051E72D /* StarToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFE7C3929AA60880051E72D /* StarToggleButton.swift */; };
@@ -145,6 +146,7 @@
 		0EA432E429A136A700C4D47F /* WithPeopleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithPeopleView.swift; sourceTree = "<group>"; };
 		0EA432E629A13EBE00C4D47F /* RelatedUrlButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelatedUrlButton.swift; sourceTree = "<group>"; };
 		0EAD37D929E6F13600C3EA38 /* BookmarkVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkVM.swift; sourceTree = "<group>"; };
+		0EB8D81129FF8C0E00E79BA4 /* PopUpType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpType.swift; sourceTree = "<group>"; };
 		0EFE7C3529AA46CA0051E72D /* ReetBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetBottomSheet.swift; sourceTree = "<group>"; };
 		0EFE7C3729AA504F0051E72D /* BookmarkBottomSheetVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkBottomSheetVC.swift; sourceTree = "<group>"; };
 		0EFE7C3929AA60880051E72D /* StarToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarToggleButton.swift; sourceTree = "<group>"; };
@@ -409,6 +411,7 @@
 				A4D09EC9299F9BAB004DEE97 /* AccountProviderType.swift */,
 				3C2AF0D62991397100E36342 /* NavigationType.swift */,
 				3CBE979D29A90A5800C0D2FE /* TabBarItem.swift */,
+				0EB8D81129FF8C0E00E79BA4 /* PopUpType.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -984,6 +987,7 @@
 				3C8A5DAA29ADCE8B007C4395 /* CategoryFilterCVC.swift in Sources */,
 				A4D09ED2299F9DDB004DEE97 /* UserInfoViewModel.swift in Sources */,
 				A4EFC0A6299E750500B066AF /* MyPageMenuDataSource.swift in Sources */,
+				0EB8D81229FF8C0E00E79BA4 /* PopUpType.swift in Sources */,
 				3C2AED5B2990B3C200E36342 /* UITextView+.swift in Sources */,
 				3CB5CCEE29B0DD0200B82DB7 /* ReetFABImage.swift in Sources */,
 				3C2AED862990B3C300E36342 /* BaseNavigationController.swift in Sources */,

--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0E2D6F2A29EBBB7D0053CD90 /* BookmarkMainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2D6F2929EBBB7D0053CD90 /* BookmarkMainModel.swift */; };
 		0E2D6F2C29EBBD180053CD90 /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2D6F2B29EBBD180053CD90 /* UIImageView+.swift */; };
+		0E2D6F5429F140A80053CD90 /* ReetPopUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2D6F5329F140A80053CD90 /* ReetPopUp.swift */; };
 		0E67036A29A201F400A5456E /* BookmarkFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E67036929A201F400A5456E /* BookmarkFilterView.swift */; };
 		0E67036E29A3CBBC00A5456E /* ReetFAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E67036D29A3CBBC00A5456E /* ReetFAB.swift */; };
 		0E8CA698299FC63300F98C15 /* BookmarkAllVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8CA697299FC63300F98C15 /* BookmarkAllVC.swift */; };
@@ -128,6 +129,7 @@
 /* Begin PBXFileReference section */
 		0E2D6F2929EBBB7D0053CD90 /* BookmarkMainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkMainModel.swift; sourceTree = "<group>"; };
 		0E2D6F2B29EBBD180053CD90 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
+		0E2D6F5329F140A80053CD90 /* ReetPopUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetPopUp.swift; sourceTree = "<group>"; };
 		0E67036929A201F400A5456E /* BookmarkFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFilterView.swift; sourceTree = "<group>"; };
 		0E67036D29A3CBBC00A5456E /* ReetFAB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetFAB.swift; sourceTree = "<group>"; };
 		0E8CA697299FC63300F98C15 /* BookmarkAllVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkAllVC.swift; sourceTree = "<group>"; };
@@ -268,6 +270,14 @@
 				3CB5CCED29B0DD0200B82DB7 /* ReetFABImage.swift */,
 			);
 			path = ReetFAB;
+			sourceTree = "<group>";
+		};
+		0E2D6F5229F1408E0053CD90 /* ReetPopUp */ = {
+			isa = PBXGroup;
+			children = (
+				0E2D6F5329F140A80053CD90 /* ReetPopUp.swift */,
+			);
+			path = ReetPopUp;
 			sourceTree = "<group>";
 		};
 		0E9122FE299BF1390023EA59 /* View */ = {
@@ -688,6 +698,7 @@
 		A4917E042996A5DC00DF2A65 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				0E2D6F5229F1408E0053CD90 /* ReetPopUp */,
 				0EFE7C3D29B05D1F0051E72D /* ReetTextField */,
 				0EFE7C3429AA46B90051E72D /* ReetBottomSheet */,
 				0E26EAE629A6670500FAB171 /* ReetFAB */,
@@ -989,6 +1000,7 @@
 				3CB5CCF029B1BB7500B82DB7 /* PlaceBottomSheet.swift in Sources */,
 				3CB5CCF229B1CF9A00B82DB7 /* PlaceInformationView.swift in Sources */,
 				A4D09ED7299F9FC7004DEE97 /* UserInfoTVC.swift in Sources */,
+				0E2D6F5429F140A80053CD90 /* ReetPopUp.swift in Sources */,
 				3CB5CCEC29B0C3C000B82DB7 /* ReetFABSize.swift in Sources */,
 				A4917E132996A84B00DF2A65 /* ButtonDefaultColorProvider.swift in Sources */,
 				3CBE979229A8703200C0D2FE /* ReetPlaceTabBarVC.swift in Sources */,

--- a/Reet-Place/Reet-Place/Global/Enum/PopUpType.swift
+++ b/Reet-Place/Reet-Place/Global/Enum/PopUpType.swift
@@ -1,0 +1,70 @@
+//
+//  PopUpType.swift
+//  Reet-Place
+//
+//  Created by 김태현 on 2023/05/01.
+//
+
+import UIKit
+
+enum PopUpType {
+    case deleteBookmark
+    case withdrawal
+}
+
+extension PopUpType {
+    var popUpTitle: String {
+        switch self {
+        case .deleteBookmark:
+            return "북마크를 해제할까요?"
+        case .withdrawal:
+            return "정말 탈퇴하시겠어요?"
+        }
+    }
+    
+    var popUpTitleFont: UIFont {
+        switch self {
+        case .deleteBookmark:
+            return AssetFonts.h4.font
+        case .withdrawal:
+            return AssetFonts.subtitle1.font
+        }
+    }
+    
+    var popUpDesc: String {
+        switch self {
+        case .deleteBookmark:
+            return "북마크를 해제하시면,\n입력하셨던 내용이 전부 사라집니다."
+        case .withdrawal:
+            return "탈퇴 이후 당신의 장소들은\n다시 복구되지 않아요."
+        }
+    }
+    
+    var popUpDescFont: UIFont {
+        switch self {
+        case .deleteBookmark:
+            return AssetFonts.body2.font
+        case .withdrawal:
+            return AssetFonts.body1.font
+        }
+    }
+    
+    var popUpDescColor: UIColor {
+        switch self {
+        case .deleteBookmark:
+            return AssetColors.error
+        case .withdrawal:
+            return AssetColors.black
+        }
+    }
+    
+    var popUpConfirmBtnTitle: String {
+        switch self {
+        case .deleteBookmark:
+            return "해제"
+        case .withdrawal:
+            return "탈퇴"
+        }
+    }
+    
+}

--- a/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
+++ b/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
@@ -104,12 +104,14 @@ extension UIViewController {
     }
       
     /// Toast Message 노출
-    func showToast(message: String) {
+    func showToast(message: String, bottomViewHeight: Double) {
         
         let toastLabel = BaseAttributedLabel(font: .body2,
                                              text: message,
                                              alignment: .center,
                                              color: AssetColors.white)
+        
+        let paddingHeight = 20.0
         
         view.addSubview(toastLabel)
         
@@ -117,7 +119,7 @@ extension UIViewController {
             $0.width.equalTo(335)
             $0.height.equalTo(45)
             $0.centerX.equalTo(view.snp.centerX)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-70.0)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-(bottomViewHeight + paddingHeight))
         }
         
         toastLabel.backgroundColor = AssetColors.gray900.withAlphaComponent(0.8)

--- a/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
+++ b/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 
 extension UIViewController {
     
@@ -102,4 +103,34 @@ extension UIViewController {
       embededViewController.removeFromParent()
     }
       
+    /// Toast Message 노출
+    func showToast(message: String) {
+        
+        let toastLabel = BaseAttributedLabel(font: .body2,
+                                             text: message,
+                                             alignment: .center,
+                                             color: AssetColors.white)
+        
+        view.addSubview(toastLabel)
+        
+        toastLabel.snp.makeConstraints {
+            $0.width.equalTo(335)
+            $0.height.equalTo(45)
+            $0.centerX.equalTo(view.snp.centerX)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-70.0)
+        }
+        
+        toastLabel.backgroundColor = AssetColors.gray900.withAlphaComponent(0.8)
+        toastLabel.alpha = 1.0
+        toastLabel.layer.cornerRadius = 4.0
+        toastLabel.clipsToBounds = true
+            
+        UIView.animate(withDuration: 0.5, delay: 2.0, options: .curveEaseOut, animations: {
+            toastLabel.alpha = 0.0
+        }, completion: {(isCompleted) in
+            toastLabel.removeFromSuperview()
+        })
+        
+    }
+    
 }

--- a/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
+++ b/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
@@ -135,4 +135,14 @@ extension UIViewController {
         
     }
     
+    func showPopUp(popUpType: PopUpType, targetVC: UIViewController, confirmBtnAction: Selector) {
+        let popUpVC = ReetPopUp()
+        
+        popUpVC.configurePopUp(popUpType: popUpType,
+                               targetVC: targetVC,
+                               confirmBtnAction: confirmBtnAction)
+        popUpVC.modalPresentationStyle = .overFullScreen
+        targetVC.present(popUpVC, animated: false)
+    }
+    
 }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
@@ -136,6 +136,8 @@ class BookmarkBottomSheetVC: ReetBottomSheet {
     let saveBtn = ReetButton(with: "저장하기",
                              for: ReetButtonStyle.primary)
     
+    let popUp = ReetPopUp()
+    
     
     // MARK: - Variables and Properties
     
@@ -396,10 +398,22 @@ extension BookmarkBottomSheetVC {
         deleteBtn.rx.tap
             .bind(onNext: { [weak self] _ in
                 guard let self = self else { return }
-                print("TODO: - Pop-up view will appear")
+                
+                self.popUp.modalPresentationStyle = .overFullScreen
+                self.present(self.popUp, animated: false)
+            })
+            .disposed(by: bag)
+        
+        // 팝업뷰 - 해제하기 버튼
+        popUp.confirmBtn.rx.tap
+            .bind(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                
+                print("TODO: - Delete Bookmark API to be call")
                 self.dismissBottomSheet()
             })
             .disposed(by: bag)
+        
         
         // 저장하기 버튼
         saveBtn.rx.tap

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
@@ -23,10 +23,10 @@ class BookmarkBottomSheetVC: ReetBottomSheet {
     }
     
     // Place Name, address, category 들어가는 View
-    let placeInformationView = PlaceInformationView()
+    private let placeInformationView = PlaceInformationView()
     
     // 아래 선택지들 들어가는 stackView
-    let selectStackView = UIStackView()
+    private let selectStackView = UIStackView()
         .then {
             $0.spacing = 12.0
             $0.distribution = .fill
@@ -35,40 +35,40 @@ class BookmarkBottomSheetVC: ReetBottomSheet {
         }
     
     // 가고싶어요, 다녀왔어요
-    let selectTypeBtn = SelectTypeButton()
+    private let selectTypeBtn = SelectTypeButton()
     
     // 릿플 점수
-    let starTitle = BaseAttributedLabel(font: .subtitle2,
+    private let starTitle = BaseAttributedLabel(font: .subtitle2,
                                         text: "릿플 점수",
                                         alignment: .left,
                                         color: AssetColors.gray700)
     
-    let starDesc = BaseAttributedLabel(font: .caption,
+    private let starDesc = BaseAttributedLabel(font: .caption,
                                        text: .empty,
                                        alignment: .left,
                                        color: AssetColors.gray500)
     
     // 별 개수 선택
-    let starToggleBtn = StarToggleButton()
+    private let starToggleBtn = StarToggleButton()
     
     // 함께할 사람들
-    let withPeopleTitle = BaseAttributedLabel(font: .subtitle2,
+    private let withPeopleTitle = BaseAttributedLabel(font: .subtitle2,
                                               text: "함께할 사람들",
                                               alignment: .left,
                                               color: AssetColors.gray700)
     
-    let withPeopleTextField = ReetTextField(style: .normal,
+    private let withPeopleTextField = ReetTextField(style: .normal,
                                             placeholderString: "ex) 최나은, 박신영, 이다정",
                                             textString: nil)
     
     // 관련 URL
-    let urlTitle = BaseAttributedLabel(font: .subtitle2,
+    private let urlTitle = BaseAttributedLabel(font: .subtitle2,
                                               text: "URL",
                                               alignment: .left,
                                               color: AssetColors.gray700)
     
     // URL 들어가는 stackView, 첫번째 url 제외하고 숨김
-    let urlStackView = UIStackView()
+    private let urlStackView = UIStackView()
         .then {
             $0.spacing = 4.0
             $0.distribution = .fill
@@ -76,18 +76,18 @@ class BookmarkBottomSheetVC: ReetBottomSheet {
             $0.axis = .vertical
         }
     
-    let firstUrl = ReetTextField(style: .normal,
+    private let firstUrl = ReetTextField(style: .normal,
                                  placeholderString: "장소와 관련된 URL을 추가해주세요. (선택)",
                                  textString: nil)
     
-    let secondUrl = ReetTextField(style: .normal,
+    private let secondUrl = ReetTextField(style: .normal,
                                   placeholderString: "장소와 관련된 URL을 추가해주세요. (선택)",
                                   textString: nil)
         .then {
             $0.isHidden = true
         }
     
-    let thirdUrl = ReetTextField(style: .normal,
+    private let thirdUrl = ReetTextField(style: .normal,
                                  placeholderString: "장소와 관련된 URL을 추가해주세요. (선택)",
                                  textString: nil)
         .then {
@@ -95,7 +95,7 @@ class BookmarkBottomSheetVC: ReetBottomSheet {
         }
     
     // URL 추가 버튼
-    let addBtn = UIButton()
+    private let addBtn = UIButton()
         .then {
             $0.setTitle("+", for: .normal)
             $0.setTitleColor(AssetColors.gray300, for: .normal)
@@ -108,13 +108,13 @@ class BookmarkBottomSheetVC: ReetBottomSheet {
         }
     
     // 수정하기 버튼
-    let modifyBtn = ReetButton(with: "수정하기",
+    private let modifyBtn = ReetButton(with: "수정하기",
                                for: ReetButtonStyle.secondary)
     
     // 해제하기 버튼
-    let deleteBtn = UIButton(type: .system)
+    private let deleteBtn = UIButton(type: .system)
     
-    let deleteStackView = UIStackView()
+    private let deleteStackView = UIStackView()
         .then {
             $0.spacing = 4.0
             $0.distribution = .fill
@@ -123,20 +123,20 @@ class BookmarkBottomSheetVC: ReetBottomSheet {
             $0.isUserInteractionEnabled = false
         }
     
-    let deleteImage = UIImageView(image: AssetsImages.delete)
+    private let deleteImage = UIImageView(image: AssetsImages.delete)
         .then {
             $0.contentMode = .scaleAspectFit
         }
     
-    let deleteLabel = BaseAttributedLabel(font: .buttonSmall,
+    private let deleteLabel = BaseAttributedLabel(font: .buttonSmall,
                                           text: "해제하기",
                                           alignment: .left,
                                           color: AssetColors.error)
     
-    let saveBtn = ReetButton(with: "저장하기",
+    private let saveBtn = ReetButton(with: "저장하기",
                              for: ReetButtonStyle.primary)
     
-    let popUp = ReetPopUp()
+    private let popUp = ReetPopUp()
     
     
     // MARK: - Variables and Properties

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
@@ -399,6 +399,7 @@ extension BookmarkBottomSheetVC {
             .bind(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 
+                self.popUp.popType = .deleteBookmark
                 self.popUp.modalPresentationStyle = .overFullScreen
                 self.present(self.popUp, animated: false)
             })

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
@@ -185,6 +185,11 @@ class BookmarkBottomSheetVC: ReetBottomSheet {
         }
     }
     
+    @objc func deleteBookmark() {
+        self.dismissBottomSheet()
+        print("TODO: - Delete Bookmark API to be call")
+    }
+    
 }
 
 
@@ -399,22 +404,12 @@ extension BookmarkBottomSheetVC {
             .bind(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 
-                self.popUp.popType = .deleteBookmark
-                self.popUp.modalPresentationStyle = .overFullScreen
-                self.present(self.popUp, animated: false)
+                self.showPopUp(popUpType: .deleteBookmark,
+                               targetVC: self,
+                               confirmBtnAction: #selector(self.deleteBookmark))
             })
             .disposed(by: bag)
-        
-        // 팝업뷰 - 해제하기 버튼
-        popUp.confirmBtn.rx.tap
-            .bind(onNext: { [weak self] _ in
-                guard let self = self else { return }
-                
-                print("TODO: - Delete Bookmark API to be call")
-                self.dismissBottomSheet()
-            })
-            .disposed(by: bag)
-        
+
         
         // 저장하기 버튼
         saveBtn.rx.tap

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkVC.swift
@@ -19,7 +19,7 @@ class BookmarkVC: BaseNavigationViewController {
     
     // MARK: - UI components
     
-    let bookmarkTypeCV: UICollectionView = {
+    private let bookmarkTypeCV: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.minimumLineSpacing = 16
         layout.scrollDirection = .vertical
@@ -28,13 +28,13 @@ class BookmarkVC: BaseNavigationViewController {
         return collectionView
     }()
     
-    var allBookmarkBtn = AllBookmarkButton(count: 12)
+    private var allBookmarkBtn = AllBookmarkButton(count: 12)
     
-    let emptyBookmarkView = EmptyBookmarkView()
+    private let emptyBookmarkView = EmptyBookmarkView()
     
-    let requestLoginView = RequestLoginView()
+    private let requestLoginView = RequestLoginView()
     
-    let induceBookmarkView = InduceBookmarkView()
+    private let induceBookmarkView = InduceBookmarkView()
     
     override var alias: String {
         "Bookmark"

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetPopUp/ReetPopUp.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetPopUp/ReetPopUp.swift
@@ -41,12 +41,12 @@ class ReetPopUp: BaseViewController {
         }
     
     let popViewTitle = BaseAttributedLabel(font: .h4,
-                                          text: "북마크를 해제할까요?",
+                                           text: .empty,
                                           alignment: .center,
                                           color: AssetColors.black)
     
     let popViewDesc = BaseAttributedLabel(font: .body2,
-                                          text: "북마크를 해제하시면,\n입력하셨던 내용이 전부 사라집니다.",
+                                          text: .empty,
                                           alignment: .center,
                                           color: AssetColors.error)
         .then {
@@ -64,13 +64,29 @@ class ReetPopUp: BaseViewController {
     let cancelBtn = ReetButton(with: "취소",
                                for: ReetButtonStyle.outlined)
     
-    let confirmBtn = ReetButton(with: "해제",
+    let confirmBtn = ReetButton(with: .empty,
                                 for: ReetButtonStyle.secondary)
     
     
     // MARK: - Variables and Properties
     
     let popViewWidth = UIScreen.main.bounds.width - 40.0
+    
+    enum PopStyle {
+        case deleteBookmark
+        case withdrawal
+    }
+    
+    var popType: PopStyle = .deleteBookmark {
+        willSet {
+            switch newValue {
+            case .deleteBookmark:
+                setDeleteBookmark()
+            case .withdrawal:
+                setWithdrawal()
+            }
+        }
+    }
     
     
     // MARK: - Life Cycle
@@ -101,7 +117,31 @@ class ReetPopUp: BaseViewController {
     
     // MARK: - Functions
     
+    func setDeleteBookmark() {
+        popViewTitle.text = "북마크를 해제할까요?"
+        popViewTitle.font = AssetFonts.h4.font
+        
+        popViewDesc.text = "북마크를 해제하시면,\n입력하셨던 내용이 전부 사라집니다."
+        popViewDesc.font = AssetFonts.body2.font
+        popViewDesc.textColor = AssetColors.error
+        
+        confirmBtn.setTitle("해제", for: .normal)
+        confirmBtn.setTitle("해제", for: .highlighted)
+        confirmBtn.setTitle("해제", for: .disabled)
+    }
     
+    func setWithdrawal() {
+        popViewTitle.text = "정말 탈퇴하시겠어요?"
+        popViewTitle.font = AssetFonts.subtitle1.font
+        
+        popViewDesc.text = "탈퇴 이후 당신의 장소들은\n다시 복구되지 않아요."
+        popViewDesc.font = AssetFonts.body1.font
+        popViewDesc.textColor = AssetColors.black
+        
+        confirmBtn.setTitle("탈퇴", for: .normal)
+        confirmBtn.setTitle("탈퇴", for: .highlighted)
+        confirmBtn.setTitle("탈퇴", for: .disabled)
+    }
     
 }
 

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetPopUp/ReetPopUp.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetPopUp/ReetPopUp.swift
@@ -19,20 +19,20 @@ class ReetPopUp: BaseViewController {
     
     // MARK: - UI components
     
-    let dimmedView = UIView()
+    private let dimmedView = UIView()
         .then {
             $0.backgroundColor = AssetColors.gray900.withAlphaComponent(0.7)
         }
     
-    let popView = UIView()
+    private let popView = UIView()
         .then {
             $0.layer.cornerRadius = 5.0
             $0.backgroundColor = .white
         }
     
-    let iconImageView = UIImageView(image: AssetsImages.map20)
+    private let iconImageView = UIImageView(image: AssetsImages.map20)
     
-    let mentStackView = UIStackView()
+    private let mentStackView = UIStackView()
         .then {
             $0.spacing = 12.0
             $0.distribution = .fill
@@ -40,12 +40,12 @@ class ReetPopUp: BaseViewController {
             $0.axis = .vertical
         }
     
-    let popViewTitle = BaseAttributedLabel(font: .h4,
+    private let popViewTitle = BaseAttributedLabel(font: .h4,
                                            text: .empty,
                                           alignment: .center,
                                           color: AssetColors.black)
     
-    let popViewDesc = BaseAttributedLabel(font: .body2,
+    private let popViewDesc = BaseAttributedLabel(font: .body2,
                                           text: .empty,
                                           alignment: .center,
                                           color: AssetColors.error)
@@ -53,7 +53,7 @@ class ReetPopUp: BaseViewController {
             $0.numberOfLines = .zero
         }
     
-    let btnStackView = UIStackView()
+    private let btnStackView = UIStackView()
         .then {
             $0.spacing = 8.0
             $0.distribution = .fillEqually
@@ -61,10 +61,10 @@ class ReetPopUp: BaseViewController {
             $0.axis = .horizontal
         }
     
-    let cancelBtn = ReetButton(with: "취소",
+    private let cancelBtn = ReetButton(with: "취소",
                                for: ReetButtonStyle.outlined)
     
-    let confirmBtn = ReetButton(with: .empty,
+    private let confirmBtn = ReetButton(with: .empty,
                                 for: ReetButtonStyle.secondary)
     
     

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetPopUp/ReetPopUp.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetPopUp/ReetPopUp.swift
@@ -1,0 +1,205 @@
+//
+//  ReetPopUpView.swift
+//  Reet-Place
+//
+//  Created by 김태현 on 2023/04/20.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+import RxSwift
+import RxCocoa
+import RxGesture
+
+
+class ReetPopUp: BaseViewController {
+    
+    // MARK: - UI components
+    
+    let dimmedView = UIView()
+        .then {
+            $0.backgroundColor = AssetColors.gray900.withAlphaComponent(0.7)
+        }
+    
+    let popView = UIView()
+        .then {
+            $0.layer.cornerRadius = 5.0
+            $0.backgroundColor = .white
+        }
+    
+    let iconImageView = UIImageView(image: AssetsImages.map20)
+    
+    let mentStackView = UIStackView()
+        .then {
+            $0.spacing = 12.0
+            $0.distribution = .fill
+            $0.alignment = .fill
+            $0.axis = .vertical
+        }
+    
+    let popViewTitle = BaseAttributedLabel(font: .h4,
+                                          text: "북마크를 해제할까요?",
+                                          alignment: .center,
+                                          color: AssetColors.black)
+    
+    let popViewDesc = BaseAttributedLabel(font: .body2,
+                                          text: "북마크를 해제하시면,\n입력하셨던 내용이 전부 사라집니다.",
+                                          alignment: .center,
+                                          color: AssetColors.error)
+        .then {
+            $0.numberOfLines = .zero
+        }
+    
+    let btnStackView = UIStackView()
+        .then {
+            $0.spacing = 8.0
+            $0.distribution = .fillEqually
+            $0.alignment = .fill
+            $0.axis = .horizontal
+        }
+    
+    let cancelBtn = ReetButton(with: "취소",
+                               for: ReetButtonStyle.outlined)
+    
+    let confirmBtn = ReetButton(with: "해제",
+                                for: ReetButtonStyle.secondary)
+    
+    
+    // MARK: - Variables and Properties
+    
+    let popViewWidth = UIScreen.main.bounds.width - 40.0
+    
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+    
+    override func configureView() {
+        super.configureView()
+        
+        configureContentView()
+    }
+    
+    override func layoutView() {
+        super.layoutView()
+        
+        configureLayout()
+    }
+    
+    override func bindInput() {
+        super.bindInput()
+        
+        bindTap()
+    }
+    
+    
+    // MARK: - Functions
+    
+    
+    
+}
+
+
+// MARK: - Configure
+
+extension ReetPopUp {
+    
+    private func configureContentView() {
+        view.backgroundColor = UIColor.clear
+        
+        [dimmedView, popView, iconImageView, mentStackView, btnStackView].forEach {
+            view.addSubview($0)
+        }
+        
+        [popViewTitle, popViewDesc].forEach {
+            mentStackView.addArrangedSubview($0)
+        }
+        
+        [cancelBtn, confirmBtn].forEach {
+            btnStackView.addArrangedSubview($0)
+        }
+    }
+    
+}
+
+
+// MARK: - Layout
+
+extension ReetPopUp {
+    
+    private func configureLayout() {
+        dimmedView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        popView.snp.makeConstraints {
+            $0.width.equalTo(popViewWidth)
+            $0.height.equalTo(257)
+            $0.center.equalToSuperview()
+        }
+        
+        iconImageView.snp.makeConstraints {
+            $0.height.width.equalTo(24)
+            $0.top.equalTo(popView).offset(33)
+            $0.centerX.equalTo(popView)
+        }
+        
+        popViewTitle.snp.makeConstraints {
+            $0.height.equalTo(28)
+        }
+        
+        mentStackView.snp.makeConstraints {
+            $0.height.equalTo(90)
+            $0.top.equalTo(popView).offset(72)
+            $0.leading.trailing.equalTo(popView).inset(24)
+        }
+        
+        btnStackView.snp.makeConstraints {
+            $0.height.equalTo(48)
+            $0.bottom.equalTo(popView).offset(-20)
+            $0.leading.trailing.equalTo(popView).inset(16)
+        }
+        
+    }
+    
+}
+
+
+// MARK: - Input
+
+extension ReetPopUp {
+    
+    private func bindTap() {
+        dimmedView.rx.tapGesture()
+            .when(.recognized)
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                
+                self.dismiss(animated: false)
+            })
+            .disposed(by: bag)
+        
+        cancelBtn.rx.tap
+            .bind(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                
+                self.dismiss(animated: false)
+            })
+            .disposed(by: bag)
+        
+        confirmBtn.rx.tap
+            .bind(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                
+                self.dismiss(animated: false)
+            })
+            .disposed(by: bag)
+    }
+    
+}

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetPopUp/ReetPopUp.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetPopUp/ReetPopUp.swift
@@ -72,22 +72,6 @@ class ReetPopUp: BaseViewController {
     
     let popViewWidth = UIScreen.main.bounds.width - 40.0
     
-    enum PopStyle {
-        case deleteBookmark
-        case withdrawal
-    }
-    
-    var popType: PopStyle = .deleteBookmark {
-        willSet {
-            switch newValue {
-            case .deleteBookmark:
-                setDeleteBookmark()
-            case .withdrawal:
-                setWithdrawal()
-            }
-        }
-    }
-    
     
     // MARK: - Life Cycle
     
@@ -116,33 +100,7 @@ class ReetPopUp: BaseViewController {
     
     
     // MARK: - Functions
-    
-    func setDeleteBookmark() {
-        popViewTitle.text = "북마크를 해제할까요?"
-        popViewTitle.font = AssetFonts.h4.font
-        
-        popViewDesc.text = "북마크를 해제하시면,\n입력하셨던 내용이 전부 사라집니다."
-        popViewDesc.font = AssetFonts.body2.font
-        popViewDesc.textColor = AssetColors.error
-        
-        confirmBtn.setTitle("해제", for: .normal)
-        confirmBtn.setTitle("해제", for: .highlighted)
-        confirmBtn.setTitle("해제", for: .disabled)
-    }
-    
-    func setWithdrawal() {
-        popViewTitle.text = "정말 탈퇴하시겠어요?"
-        popViewTitle.font = AssetFonts.subtitle1.font
-        
-        popViewDesc.text = "탈퇴 이후 당신의 장소들은\n다시 복구되지 않아요."
-        popViewDesc.font = AssetFonts.body1.font
-        popViewDesc.textColor = AssetColors.black
-        
-        confirmBtn.setTitle("탈퇴", for: .normal)
-        confirmBtn.setTitle("탈퇴", for: .highlighted)
-        confirmBtn.setTitle("탈퇴", for: .disabled)
-    }
-    
+
 }
 
 
@@ -166,6 +124,20 @@ extension ReetPopUp {
         }
     }
     
+    func configurePopUp(popUpType: PopUpType, targetVC: UIViewController, confirmBtnAction: Selector) {
+        popViewTitle.text = popUpType.popUpTitle
+        popViewTitle.font = popUpType.popUpTitleFont
+        
+        popViewDesc.text = popUpType.popUpDesc
+        popViewDesc.font = popUpType.popUpDescFont
+        popViewDesc.textColor = popUpType.popUpDescColor
+        
+        confirmBtn.setTitle(popUpType.popUpConfirmBtnTitle, for: .normal)
+        confirmBtn.setTitle(popUpType.popUpConfirmBtnTitle, for: .highlighted)
+        confirmBtn.setTitle(popUpType.popUpConfirmBtnTitle, for: .disabled)
+        
+        confirmBtn.addTarget(targetVC, action: confirmBtnAction, for: .touchUpInside)
+    }
 }
 
 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
> Custom Pop up view - ReetPopUp 구현
> Toast Message 구현

## 📋 변경 사항
### 1. Custom Pop up View -> ReetPopUp 구현
- 북마크 해제, 탈퇴 시 노출되는 Pop Up View 구현했습니다.
- PopUp 타입은 2가지로 나뉘어져 있고, 아래와 같이 호출 가능합니다.
~~~ swift
let popUp = ReetPopUp()

// PopUp 타입 지정
popUp.popType = .deleteBookmark
popUp.popType = .withdrawal

popUp.modalPresentationStyle = .overFullScreen
present(self.popUp, animated: false)
~~~
- ReetPopUp에서 cancelBtn은 "취소" 버튼, confirmBtn은 "해제" 또는 "탈퇴" 입니다.
### 2. Toast Message 구현
- UIViewController+에 함수로 구현되어 있습니다.
- VC에서 아래와 같이 호출 가능합니다.
~~~ swift
showToast(message: "저장이 완료되었어요 !", bottomViewHeight: 0.0)
~~~
- **paddingHeight** (20.0)는 기본으로 반영되어 있고, **bottomViewHeight**로 Toast Message 아래에 추가로 들어가는 뷰 높이를 인자로 전달해주시면 됩니다. 각 높이는 아래 그림 참고해주세용
<img src="https://user-images.githubusercontent.com/51712973/233907562-9046dfbe-a5cb-4249-83da-24e752acc4f4.jpeg" width="600px" />

## 🔍 Code Review
현재 Toast Message animate에서 노출 시간, 사라지는 시간은 임의로 각각 2초, 0.5초로 설정되어 있는데, 이 부분은 디자이너분들께 나중에 한번 여쭤보고 수정하겠습니다!

## 📸 ScreenShot
<img src="https://user-images.githubusercontent.com/51712973/233907864-1ab76e1b-67b3-442b-b791-0a6f8b7e3cd5.png" width="300px" />
<img src="https://user-images.githubusercontent.com/51712973/233907875-8acb048f-4a7c-40f2-9ebc-a107776e92e4.png" width="300px" />
<img src="https://user-images.githubusercontent.com/51712973/233908099-d603d60f-e47b-43a6-9c0b-d384d698a0f0.png" width="300px" />

### 연결된 이슈 Close
close #34 
close #35 
