### PR TITLE
Feat/#29 Custom Select Box 구현

### DIFF
--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E05EFFC2A492CA9008A20F4 /* SelectBoxStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E05EFFB2A492CA9008A20F4 /* SelectBoxStyle.swift */; };
 		0E2D6F2A29EBBB7D0053CD90 /* BookmarkMainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2D6F2929EBBB7D0053CD90 /* BookmarkMainModel.swift */; };
 		0E2D6F2C29EBBD180053CD90 /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2D6F2B29EBBD180053CD90 /* UIImageView+.swift */; };
 		0E2D6F5429F140A80053CD90 /* ReetPopUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2D6F5329F140A80053CD90 /* ReetPopUp.swift */; };
@@ -170,6 +171,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0E05EFFB2A492CA9008A20F4 /* SelectBoxStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectBoxStyle.swift; sourceTree = "<group>"; };
 		0E2D6F2929EBBB7D0053CD90 /* BookmarkMainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkMainModel.swift; sourceTree = "<group>"; };
 		0E2D6F2B29EBBD180053CD90 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		0E2D6F5329F140A80053CD90 /* ReetPopUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetPopUp.swift; sourceTree = "<group>"; };
@@ -429,6 +431,7 @@
 			isa = PBXGroup;
 			children = (
 				0EAFCFD92A2883C50023A738 /* ReetSelectBox.swift */,
+				0E05EFFB2A492CA9008A20F4 /* SelectBoxStyle.swift */,
 				0EAFCFDB2A2888700023A738 /* SelectBoxTVC.swift */,
 			);
 			path = ReetSelectBox;
@@ -1195,6 +1198,7 @@
 				A4AABE6F299BC0D400BA9D37 /* AssetFonts.swift in Sources */,
 				3C2AED652990B3C200E36342 /* UIImage+.swift in Sources */,
 				3C976C7F29AA3F860002F8A7 /* CaseIterable+.swift in Sources */,
+				0E05EFFC2A492CA9008A20F4 /* SelectBoxStyle.swift in Sources */,
 				0EFE7C3C29ABBC870051E72D /* SelectTypeButton.swift in Sources */,
 				A4EFC09E299E6F0100B066AF /* DefaultCategoryTVC.swift in Sources */,
 				A4EFC08D299E48AD00B066AF /* MyPageViewModel.swift in Sources */,

--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		0EA432E529A136A700C4D47F /* WithPeopleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA432E429A136A700C4D47F /* WithPeopleView.swift */; };
 		0EA432E729A13EBE00C4D47F /* RelatedUrlButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA432E629A13EBE00C4D47F /* RelatedUrlButton.swift */; };
 		0EAD37DA29E6F13600C3EA38 /* BookmarkVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAD37D929E6F13600C3EA38 /* BookmarkVM.swift */; };
+		0EAFCFDA2A2883C50023A738 /* ReetSelectBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAFCFD92A2883C50023A738 /* ReetSelectBox.swift */; };
 		0EB8D81229FF8C0E00E79BA4 /* PopUpType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB8D81129FF8C0E00E79BA4 /* PopUpType.swift */; };
 		0EB8D81429FFFF9D00E79BA4 /* AccountDeletedVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB8D81329FFFF9D00E79BA4 /* AccountDeletedVC.swift */; };
 		0EED226B29F8C77900C8102E /* DeleteAccountVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EED226A29F8C77900C8102E /* DeleteAccountVM.swift */; };
@@ -190,6 +191,7 @@
 		0EA432E429A136A700C4D47F /* WithPeopleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithPeopleView.swift; sourceTree = "<group>"; };
 		0EA432E629A13EBE00C4D47F /* RelatedUrlButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelatedUrlButton.swift; sourceTree = "<group>"; };
 		0EAD37D929E6F13600C3EA38 /* BookmarkVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkVM.swift; sourceTree = "<group>"; };
+		0EAFCFD92A2883C50023A738 /* ReetSelectBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetSelectBox.swift; sourceTree = "<group>"; };
 		0EB8D81129FF8C0E00E79BA4 /* PopUpType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpType.swift; sourceTree = "<group>"; };
 		0EB8D81329FFFF9D00E79BA4 /* AccountDeletedVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeletedVC.swift; sourceTree = "<group>"; };
 		0EED226A29F8C77900C8102E /* DeleteAccountVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountVM.swift; sourceTree = "<group>"; };
@@ -419,6 +421,14 @@
 				0EA432E629A13EBE00C4D47F /* RelatedUrlButton.swift */,
 			);
 			path = BookmarkCard;
+			sourceTree = "<group>";
+		};
+		0EAFCFD62A2883960023A738 /* ReetSelectBox */ = {
+			isa = PBXGroup;
+			children = (
+				0EAFCFD92A2883C50023A738 /* ReetSelectBox.swift */,
+			);
+			path = ReetSelectBox;
 			sourceTree = "<group>";
 		};
 		0EED226F29F8CB5C00C8102E /* View */ = {
@@ -866,6 +876,7 @@
 			children = (
 				3C2784172A0A65B50095B706 /* ReetTabButton */,
 				3C2784142A0A3C5D0095B706 /* ReetMenuTabBar */,
+				0EAFCFD62A2883960023A738 /* ReetSelectBox */,
 				0E2D6F5229F1408E0053CD90 /* ReetPopUp */,
 				0EFE7C3D29B05D1F0051E72D /* ReetTextField */,
 				0EFE7C3429AA46B90051E72D /* ReetBottomSheet */,
@@ -1194,6 +1205,7 @@
 				3C27841B2A0A67060095B706 /* ReetTabButtonStyle.swift in Sources */,
 				3CB5CCF229B1CF9A00B82DB7 /* PlaceInformationView.swift in Sources */,
 				A4D09ED7299F9FC7004DEE97 /* UserInfoTVC.swift in Sources */,
+				0EAFCFDA2A2883C50023A738 /* ReetSelectBox.swift in Sources */,
 				0E2D6F5429F140A80053CD90 /* ReetPopUp.swift in Sources */,
 				0E5A514629F675F300C44701 /* DeleteAccountVC.swift in Sources */,
 				3CB5CCEC29B0C3C000B82DB7 /* ReetFABSize.swift in Sources */,

--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		0EA432E729A13EBE00C4D47F /* RelatedUrlButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA432E629A13EBE00C4D47F /* RelatedUrlButton.swift */; };
 		0EAD37DA29E6F13600C3EA38 /* BookmarkVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAD37D929E6F13600C3EA38 /* BookmarkVM.swift */; };
 		0EAFCFDA2A2883C50023A738 /* ReetSelectBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAFCFD92A2883C50023A738 /* ReetSelectBox.swift */; };
+		0EAFCFDC2A2888700023A738 /* SelectBoxTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAFCFDB2A2888700023A738 /* SelectBoxTVC.swift */; };
 		0EB8D81229FF8C0E00E79BA4 /* PopUpType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB8D81129FF8C0E00E79BA4 /* PopUpType.swift */; };
 		0EB8D81429FFFF9D00E79BA4 /* AccountDeletedVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB8D81329FFFF9D00E79BA4 /* AccountDeletedVC.swift */; };
 		0EED226B29F8C77900C8102E /* DeleteAccountVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EED226A29F8C77900C8102E /* DeleteAccountVM.swift */; };
@@ -192,6 +193,7 @@
 		0EA432E629A13EBE00C4D47F /* RelatedUrlButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelatedUrlButton.swift; sourceTree = "<group>"; };
 		0EAD37D929E6F13600C3EA38 /* BookmarkVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkVM.swift; sourceTree = "<group>"; };
 		0EAFCFD92A2883C50023A738 /* ReetSelectBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetSelectBox.swift; sourceTree = "<group>"; };
+		0EAFCFDB2A2888700023A738 /* SelectBoxTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectBoxTVC.swift; sourceTree = "<group>"; };
 		0EB8D81129FF8C0E00E79BA4 /* PopUpType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpType.swift; sourceTree = "<group>"; };
 		0EB8D81329FFFF9D00E79BA4 /* AccountDeletedVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeletedVC.swift; sourceTree = "<group>"; };
 		0EED226A29F8C77900C8102E /* DeleteAccountVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountVM.swift; sourceTree = "<group>"; };
@@ -427,6 +429,7 @@
 			isa = PBXGroup;
 			children = (
 				0EAFCFD92A2883C50023A738 /* ReetSelectBox.swift */,
+				0EAFCFDB2A2888700023A738 /* SelectBoxTVC.swift */,
 			);
 			path = ReetSelectBox;
 			sourceTree = "<group>";
@@ -1286,6 +1289,7 @@
 				0EA432D929A0894400C4D47F /* BookmarkWishlistVC.swift in Sources */,
 				3C9256682A1CCFE00011B093 /* CategoryDetailActivityDataSource.swift in Sources */,
 				A4EFC08B299E488500B066AF /* MyPageVC.swift in Sources */,
+				0EAFCFDC2A2888700023A738 /* SelectBoxTVC.swift in Sources */,
 				A4D09EC8299F984A004DEE97 /* UserInfoVC.swift in Sources */,
 				3C9256742A1CE26B0011B093 /* CategoryDetailShoppingList.swift in Sources */,
 				3C9256842A1CE6AA0011B093 /* CategoryDetailCultureView.swift in Sources */,

--- a/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
+++ b/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
@@ -135,6 +135,7 @@ extension UIViewController {
         
     }
     
+    /// Pop Up 노출
     func showPopUp(popUpType: PopUpType, targetVC: UIViewController, confirmBtnAction: Selector) {
         let popUpVC = ReetPopUp()
         
@@ -145,12 +146,17 @@ extension UIViewController {
         targetVC.present(popUpVC, animated: false)
     }
     
-    func showSelectBox(targetVC: UIViewController, location: CGRect, style: SelectBoxStyle) {
+    /// Select Box 노출
+    func showSelectBox(targetVC: UIViewController, location: CGRect, style: SelectBoxStyle, completion: @escaping (Int) -> Void) {
         let selectBoxVC = ReetSelectBox()
         
         selectBoxVC.location = location
         selectBoxVC.style = style
         selectBoxVC.modalPresentationStyle = .overFullScreen
+        
+        selectBoxVC.selected = { row in
+            completion(row)
+        }
         
         targetVC.present(selectBoxVC, animated: false)
     }

--- a/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
+++ b/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
@@ -145,10 +145,11 @@ extension UIViewController {
         targetVC.present(popUpVC, animated: false)
     }
     
-    func showSelectBox(targetVC: UIViewController, location: CGRect) {
+    func showSelectBox(targetVC: UIViewController, location: CGRect, style: SelectBoxStyle) {
         let selectBoxVC = ReetSelectBox()
         
         selectBoxVC.location = location
+        selectBoxVC.style = style
         selectBoxVC.modalPresentationStyle = .overFullScreen
         
         targetVC.present(selectBoxVC, animated: false)

--- a/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
+++ b/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
@@ -145,4 +145,13 @@ extension UIViewController {
         targetVC.present(popUpVC, animated: false)
     }
     
+    func showSelectBox(targetVC: UIViewController, location: CGRect) {
+        let selectBoxVC = ReetSelectBox()
+        
+        selectBoxVC.location = location
+        selectBoxVC.modalPresentationStyle = .overFullScreen
+        
+        targetVC.present(selectBoxVC, animated: false)
+    }
+    
 }

--- a/Reet-Place/Reet-Place/Screen/BookMark/Cell/BookmarkCardTVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/Cell/BookmarkCardTVC.swift
@@ -17,7 +17,7 @@ import RxCocoa
 
 protocol BookmarkCardAction {
     func infoToggle(index: Int)
-    func showMenu(index: Int)
+    func showMenu(index: Int, location: CGRect)
 }
 
 class BookmarkCardTVC: BaseTableViewCell {
@@ -419,8 +419,12 @@ extension BookmarkCardTVC {
         cardMenuBtn.rx.tap
             .bind(onNext: { [weak self] _ in
                 guard let self = self,
-                      let index = self.index else { return }
-                self.delegate?.showMenu(index: index)
+                      let index = self.index,
+                      let owner = self.findViewController() else { return }
+
+                let btnFrameInSuperview = owner.view.convert(self.cardMenuBtn.frame, from: self.iconStackView)
+                
+                self.delegate?.showMenu(index: index, location: btnFrameInSuperview)
             })
             .disposed(by: bag)
     }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
@@ -186,13 +186,8 @@ extension BookmarkAllVC: BookmarkCardAction {
         tableView.reloadData()
     }
     
-    func showMenu(index: Int) {
-        let bottomSheetVC = BookmarkBottomSheetVC()
-        let cardInfo = viewModel.output.cardList.value[index]
-        bottomSheetVC.configureSheetData(with: cardInfo)
-        
-        bottomSheetVC.modalPresentationStyle = .overFullScreen
-        present(bottomSheetVC, animated: false)
+    func showMenu(index: Int, location: CGRect) {
+        showSelectBox(targetVC: self, location: location)
     }
 
 }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
@@ -187,7 +187,28 @@ extension BookmarkAllVC: BookmarkCardAction {
     }
     
     func showMenu(index: Int, location: CGRect) {
-        showSelectBox(targetVC: self, location: location, style: .bookmarked)
+        showSelectBox(targetVC: self, location: location, style: .bookmarked) { row in
+            if row == 0 {
+                self.showBottomSheet(index: index)
+            }
+            
+            if row == 1 {
+                print("TODO: - Copy Link to be call")
+            }
+            
+            if row == 2 {
+                print("TODO: - Delete Bookmark API to be call")
+            }
+        }
+    }
+    
+    func showBottomSheet(index: Int) {
+        let bottomSheetVC = BookmarkBottomSheetVC()
+        let cardInfo = viewModel.output.cardList.value[index]
+        bottomSheetVC.configureSheetData(with: cardInfo)
+                
+        bottomSheetVC.modalPresentationStyle = .overFullScreen
+        present(bottomSheetVC, animated: false)
     }
 
 }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
@@ -187,7 +187,7 @@ extension BookmarkAllVC: BookmarkCardAction {
     }
     
     func showMenu(index: Int, location: CGRect) {
-        showSelectBox(targetVC: self, location: location)
+        showSelectBox(targetVC: self, location: location, style: .bookmarked)
     }
 
 }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
@@ -187,7 +187,9 @@ extension BookmarkAllVC: BookmarkCardAction {
     }
     
     func showMenu(index: Int, location: CGRect) {
-        showSelectBox(targetVC: self, location: location, style: .bookmarked) { row in
+        showSelectBox(targetVC: self, location: location, style: .bookmarked) { [weak self] row in
+            guard let self = self else { return }
+            
             if row == 0 {
                 self.showBottomSheet(index: index)
             }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
@@ -188,12 +188,7 @@ extension BookmarkHistoryVC: BookmarkCardAction {
     }
     
     func showMenu(index: Int, location: CGRect) {
-        let bottomSheetVC = BookmarkBottomSheetVC()
-        let cardInfo = viewModel.output.cardList.value[index]
-        bottomSheetVC.configureSheetData(with: cardInfo)
-        
-        bottomSheetVC.modalPresentationStyle = .overFullScreen
-        present(bottomSheetVC, animated: false)
+        showSelectBox(targetVC: self, location: location, style: .bookmarked)
     }
 
 }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
@@ -187,7 +187,7 @@ extension BookmarkHistoryVC: BookmarkCardAction {
         tableView.reloadData()
     }
     
-    func showMenu(index: Int) {
+    func showMenu(index: Int, location: CGRect) {
         let bottomSheetVC = BookmarkBottomSheetVC()
         let cardInfo = viewModel.output.cardList.value[index]
         bottomSheetVC.configureSheetData(with: cardInfo)

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
@@ -188,7 +188,28 @@ extension BookmarkHistoryVC: BookmarkCardAction {
     }
     
     func showMenu(index: Int, location: CGRect) {
-        showSelectBox(targetVC: self, location: location, style: .bookmarked)
+        showSelectBox(targetVC: self, location: location, style: .bookmarked) { row in
+            if row == 0 {
+                self.showBottomSheet(index: index)
+            }
+            
+            if row == 1 {
+                print("TODO: - Copy Link to be call")
+            }
+            
+            if row == 2 {
+                print("TODO: - Delete Bookmark API to be call")
+            }
+        }
+    }
+    
+    func showBottomSheet(index: Int) {
+        let bottomSheetVC = BookmarkBottomSheetVC()
+        let cardInfo = viewModel.output.cardList.value[index]
+        bottomSheetVC.configureSheetData(with: cardInfo)
+                
+        bottomSheetVC.modalPresentationStyle = .overFullScreen
+        present(bottomSheetVC, animated: false)
     }
 
 }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
@@ -188,7 +188,9 @@ extension BookmarkHistoryVC: BookmarkCardAction {
     }
     
     func showMenu(index: Int, location: CGRect) {
-        showSelectBox(targetVC: self, location: location, style: .bookmarked) { row in
+        showSelectBox(targetVC: self, location: location, style: .bookmarked) { [weak self] row in
+            guard let self = self else { return }
+            
             if row == 0 {
                 self.showBottomSheet(index: index)
             }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
@@ -187,7 +187,7 @@ extension BookmarkWishlistVC: BookmarkCardAction {
     }
     
     func showMenu(index: Int, location: CGRect) {
-        showSelectBox(targetVC: self, location: location)
+        showSelectBox(targetVC: self, location: location, style: .bookmarked)
     }
 
 }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
@@ -187,7 +187,9 @@ extension BookmarkWishlistVC: BookmarkCardAction {
     }
     
     func showMenu(index: Int, location: CGRect) {
-        showSelectBox(targetVC: self, location: location, style: .bookmarked) { row in
+        showSelectBox(targetVC: self, location: location, style: .bookmarked) { [weak self] row in
+            guard let self = self else { return }
+            
             if row == 0 {
                 self.showBottomSheet(index: index)
             }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
@@ -186,13 +186,8 @@ extension BookmarkWishlistVC: BookmarkCardAction {
         tableView.reloadData()
     }
     
-    func showMenu(index: Int) {
-        let bottomSheetVC = BookmarkBottomSheetVC()
-        let cardInfo = viewModel.output.cardList.value[index]
-        bottomSheetVC.configureSheetData(with: cardInfo)
-        
-        bottomSheetVC.modalPresentationStyle = .overFullScreen
-        present(bottomSheetVC, animated: false)
+    func showMenu(index: Int, location: CGRect) {
+        showSelectBox(targetVC: self, location: location)
     }
 
 }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
@@ -187,7 +187,28 @@ extension BookmarkWishlistVC: BookmarkCardAction {
     }
     
     func showMenu(index: Int, location: CGRect) {
-        showSelectBox(targetVC: self, location: location, style: .bookmarked)
+        showSelectBox(targetVC: self, location: location, style: .bookmarked) { row in
+            if row == 0 {
+                self.showBottomSheet(index: index)
+            }
+            
+            if row == 1 {
+                print("TODO: - Copy Link to be call")
+            }
+            
+            if row == 2 {
+                print("TODO: - Delete Bookmark API to be call")
+            }
+        }
+    }
+    
+    func showBottomSheet(index: Int) {
+        let bottomSheetVC = BookmarkBottomSheetVC()
+        let cardInfo = viewModel.output.cardList.value[index]
+        bottomSheetVC.configureSheetData(with: cardInfo)
+                
+        bottomSheetVC.modalPresentationStyle = .overFullScreen
+        present(bottomSheetVC, animated: false)
     }
 
 }

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
@@ -25,7 +25,7 @@ class ReetSelectBox: BaseViewController {
     
     private let tableView: UITableView = UITableView(frame: .zero, style: .plain)
         .then {
-            $0.rowHeight = UITableView.automaticDimension
+            $0.rowHeight = 33.0
             $0.layer.cornerRadius = 5.0
             $0.isScrollEnabled = false
             $0.separatorStyle = .none
@@ -36,6 +36,8 @@ class ReetSelectBox: BaseViewController {
     // MARK: - Variables and Properties
     
     var location: CGRect?
+    
+    var style: SelectBoxStyle = .bookmarked
     
     var firstAction: (() -> Void)?
     var secondAction: (() -> Void)?
@@ -108,7 +110,7 @@ extension ReetSelectBox {
         }
         
         tableView.snp.makeConstraints {
-            $0.height.equalTo(111.0)
+            $0.height.equalTo(33 * self.style.numberOfRows)
             $0.width.equalTo(120.0)
             $0.top.equalToSuperview().offset(location?.maxY ?? 0.0)
             $0.trailing.equalToSuperview().offset(-(screenWidth - (location?.maxX ?? 0.0)))
@@ -139,9 +141,7 @@ extension ReetSelectBox {
 // MARK: - UITableViewDelegate
 
 extension ReetSelectBox: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        54.0
-    }
+    
 }
 
 
@@ -149,11 +149,13 @@ extension ReetSelectBox: UITableViewDelegate {
 
 extension ReetSelectBox: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        3
+        style.numberOfRows
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: SelectBoxTVC.className, for: indexPath) as? SelectBoxTVC else { fatalError("No such Cell") }
+        
+        cell.setLabel(title: style.selectTitle[indexPath.row])
         
         return cell
     }

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
@@ -18,10 +18,30 @@ class ReetSelectBox: BaseViewController {
     
     // MARK: - UI components
     
+    private let backgroundView: UIView = UIView()
+        .then {
+            $0.backgroundColor = .clear
+        }
+    
+    private let tableView: UITableView = UITableView(frame: .zero, style: .plain)
+        .then {
+            $0.rowHeight = UITableView.automaticDimension
+            $0.layer.cornerRadius = 5.0
+            $0.isScrollEnabled = false
+            $0.separatorStyle = .none
+            $0.showsVerticalScrollIndicator = false
+        }
+    
     
     // MARK: - Variables and Properties
     
+    var location: CGRect?
     
+    var firstAction: (() -> Void)?
+    var secondAction: (() -> Void)?
+    var thirdAction: (() -> Void)?
+    
+
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -51,7 +71,11 @@ class ReetSelectBox: BaseViewController {
 extension ReetSelectBox {
     
     private func configureContentView() {
+        view.addSubviews([backgroundView, tableView])
         
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(SelectBoxTVC.self, forCellReuseIdentifier: SelectBoxTVC.className)
     }
     
 }
@@ -62,7 +86,40 @@ extension ReetSelectBox {
 extension ReetSelectBox {
     
     private func configureLayout() {
+        backgroundView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
         
+        tableView.snp.makeConstraints {
+            $0.height.equalTo(150.0)
+            $0.width.equalTo(100.0)
+            $0.top.equalToSuperview().offset((location?.origin.y ?? 0.0) + 50.0)
+            $0.trailing.equalToSuperview().offset(-(screenWidth - (location?.maxX ?? 0.0)))
+        }
     }
     
+}
+
+
+// MARK: - UITableViewDelegate
+
+extension ReetSelectBox: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        54.0
+    }
+}
+
+
+// MARK: - UITableViewDataSource
+
+extension ReetSelectBox: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        3
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: SelectBoxTVC.className, for: indexPath) as? SelectBoxTVC else { fatalError("No such Cell") }
+        
+        return cell
+    }
 }

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
@@ -1,0 +1,68 @@
+//
+//  ReetSelectBox.swift
+//  Reet-Place
+//
+//  Created by 김태현 on 2023/06/01.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+import RxSwift
+import RxCocoa
+import RxGesture
+
+class ReetSelectBox: BaseViewController {
+    
+    // MARK: - UI components
+    
+    
+    // MARK: - Variables and Properties
+    
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+    
+    override func configureView() {
+        super.configureView()
+        
+        configureContentView()
+    }
+    
+    override func layoutView() {
+        super.layoutView()
+        
+        configureLayout()
+    }
+    
+    // MARK: - Functions
+    
+}
+
+
+// MARK: - Configure
+
+extension ReetSelectBox {
+    
+    private func configureContentView() {
+        
+    }
+    
+}
+
+
+// MARK: - Layout
+
+extension ReetSelectBox {
+    
+    private func configureLayout() {
+        
+    }
+    
+}

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
@@ -39,9 +39,7 @@ class ReetSelectBox: BaseViewController {
     
     var style: SelectBoxStyle = .bookmarked
     
-    var firstAction: (() -> Void)?
-    var secondAction: (() -> Void)?
-    var thirdAction: (() -> Void)?
+    var selected: ((Int) -> Void)?
     
 
     // MARK: - Life Cycle
@@ -158,5 +156,10 @@ extension ReetSelectBox: UITableViewDataSource {
         cell.setLabel(title: style.selectTitle[indexPath.row])
         
         return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        dismiss(animated: false)
+        selected?(indexPath.row)
     }
 }

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
@@ -53,6 +53,7 @@ class ReetSelectBox: BaseViewController {
         super.configureView()
         
         configureContentView()
+        configureShadow()
     }
     
     override func layoutView() {
@@ -86,6 +87,14 @@ extension ReetSelectBox {
         tableView.register(SelectBoxTVC.self, forCellReuseIdentifier: SelectBoxTVC.className)
     }
     
+    private func configureShadow() {
+        view.layer.shadowColor = CGColor(red: 0.0 / 255.0, green: 0.0 / 255.0, blue: 0.0 / 255.0, alpha: 1)
+        view.layer.shadowOpacity = 0.25
+        view.layer.shadowRadius = 4.0
+        view.layer.shadowOffset = CGSize(width: 0, height: 4.0)
+        view.layer.masksToBounds = false
+    }
+    
 }
 
 
@@ -99,9 +108,9 @@ extension ReetSelectBox {
         }
         
         tableView.snp.makeConstraints {
-            $0.height.equalTo(150.0)
-            $0.width.equalTo(100.0)
-            $0.top.equalToSuperview().offset((location?.origin.y ?? 0.0) + 50.0)
+            $0.height.equalTo(111.0)
+            $0.width.equalTo(120.0)
+            $0.top.equalToSuperview().offset(location?.maxY ?? 0.0)
             $0.trailing.equalToSuperview().offset(-(screenWidth - (location?.maxX ?? 0.0)))
         }
     }

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/ReetSelectBox.swift
@@ -61,6 +61,12 @@ class ReetSelectBox: BaseViewController {
         configureLayout()
     }
     
+    override func bindInput() {
+        super.bindInput()
+        
+        bindView()
+    }
+    
     // MARK: - Functions
     
 }
@@ -71,6 +77,8 @@ class ReetSelectBox: BaseViewController {
 extension ReetSelectBox {
     
     private func configureContentView() {
+        view.backgroundColor = UIColor.clear
+        
         view.addSubviews([backgroundView, tableView])
         
         tableView.delegate = self
@@ -96,6 +104,24 @@ extension ReetSelectBox {
             $0.top.equalToSuperview().offset((location?.origin.y ?? 0.0) + 50.0)
             $0.trailing.equalToSuperview().offset(-(screenWidth - (location?.maxX ?? 0.0)))
         }
+    }
+    
+}
+
+
+// MARK: - Bind
+
+extension ReetSelectBox {
+    
+    private func bindView() {
+        backgroundView.rx.tapGesture()
+            .when(.recognized)
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                
+                self.dismiss(animated: false)
+            })
+            .disposed(by: bag)
     }
     
 }

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/SelectBoxStyle.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/SelectBoxStyle.swift
@@ -1,0 +1,35 @@
+//
+//  SelectBoxStyle.swift
+//  Reet-Place
+//
+//  Created by 김태현 on 2023/06/26.
+//
+
+import UIKit
+
+enum SelectBoxStyle: String {
+    case bookmarked
+    case notBookmarked
+}
+
+extension SelectBoxStyle {
+    
+    var selectTitle: [String] {
+        switch self {
+        case .bookmarked:
+            return ["북마크 수정", "링크복사", "북마크 삭제"]
+        case .notBookmarked:
+            return ["북마크", "공유하기"]
+        }
+    }
+    
+    var numberOfRows: Int {
+        switch self {
+        case .bookmarked:
+            return 3
+        case .notBookmarked:
+            return 2
+        }
+    }
+    
+}

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/SelectBoxTVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/SelectBoxTVC.swift
@@ -1,0 +1,70 @@
+//
+//  SelectBoxTVC.swift
+//  Reet-Place
+//
+//  Created by 김태현 on 2023/06/01.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class SelectBoxTVC: BaseTableViewCell {
+    
+    // MARK: - UI components
+    
+    private let selectLabel: BaseAttributedLabel = BaseAttributedLabel(font: .body2,
+                                                                       text: .empty,
+                                                                       alignment: .left,
+                                                                       color: AssetColors.black)
+    
+    
+    // MARK: - Variables and Properties
+    
+    
+    // MARK: - Life Cycle
+    
+    override func configureView() {
+        super.configureView()
+        
+        configureContentView()
+    }
+    
+    override func layoutView() {
+        super.layoutView()
+        
+        configureLayout()
+    }
+    
+    // MARK: - Functions
+    
+}
+
+
+// MARK: - Configure
+
+extension SelectBoxTVC {
+    
+    private func configureContentView() {
+        contentView.addSubviews([selectLabel])
+        
+    }
+    
+}
+
+
+// MARK: - Layout
+
+extension SelectBoxTVC {
+    
+    private func configureLayout() {
+        selectLabel.snp.makeConstraints {
+            $0.height.equalTo(21.0)
+            $0.width.equalTo(96.0)
+            $0.edges.equalToSuperview()
+        }
+        
+    }
+    
+}

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/SelectBoxTVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/SelectBoxTVC.swift
@@ -62,7 +62,6 @@ extension SelectBoxTVC {
         selectLabel.snp.makeConstraints {
             $0.height.equalTo(21.0)
             $0.width.equalTo(96.0)
-            $0.edges.equalToSuperview()
         }
         
     }

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/SelectBoxTVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/SelectBoxTVC.swift
@@ -14,7 +14,7 @@ class SelectBoxTVC: BaseTableViewCell {
     
     // MARK: - UI components
     
-    private let selectLabel: BaseAttributedLabel = BaseAttributedLabel(font: .body2,
+    let selectLabel: BaseAttributedLabel = BaseAttributedLabel(font: .body2,
                                                                        text: .empty,
                                                                        alignment: .left,
                                                                        color: AssetColors.black)
@@ -37,7 +37,22 @@ class SelectBoxTVC: BaseTableViewCell {
         configureLayout()
     }
     
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        configureInset()
+    }
+    
+    
     // MARK: - Functions
+    
+    func setLabel(title: String) {
+        selectLabel.text = title
+        
+        if title == "북마크 삭제" {
+            selectLabel.textColor = AssetColors.error
+        }
+    }
     
 }
 
@@ -51,6 +66,11 @@ extension SelectBoxTVC {
         
     }
     
+    private func configureInset() {
+        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 6.0, left: 12.0, bottom: 6.0, right: 12.0))
+        
+    }
+    
 }
 
 
@@ -60,8 +80,7 @@ extension SelectBoxTVC {
     
     private func configureLayout() {
         selectLabel.snp.makeConstraints {
-            $0.height.equalTo(21.0)
-            $0.width.equalTo(96.0)
+            $0.edges.equalToSuperview()
         }
         
     }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
> Custom Select Box 구현

## 📋 변경 사항
### 1. ReetSelectBox 구현
- SelectBoxStyle을 통해 현재 필요한 두 가지 스타일의 SelectBox를 구현했습니다. (`bookmarked`, `notBookmarked`)
- UIViewController+ 의 showSelectBox 함수를 통해 SelectBox를 노출할 수 있습니다.
- SelectBox 노출 시에 위치를 잡아주어야하는데, 노출해야할 버튼 아래 위치를 convert 함수를 통해 구할 수 있었습니다. 예를 들어, `owner.view.convert(self.cardMenuBtn.frame, from: self.iconStackView)` 와 같은 코드에서 cardMenuBtn의 frame을 현재 iconStackView 기준인 것에서 VC(owner)의 view 기준으로 변환할 수 있습니다. (SelectBox의 위치를 VC 기준으로 변환하기 위함)
- SelectBox의 이벤트 전달은 closure와 completion handler를 통해 구현했습니다. ReetSelectBox (VC) 에서 메뉴를 선택하면 -> `selected` closure를 통해 호출했던 showSelectBox로 선택한 메뉴의 row를 전달하고, -> showSelectBox에서는 completion handler를 통해 호출했던 VC로 row를 전달합니다. 이후 VC에서 전달받은 row에 따라 필요한 이벤트를 처리하면 됩니다. (북마크, 공유하기, 북마크 수정.. 등등)
- 아래와 같이 호출하고 처리해주시면 됩니당.
~~~swift
showSelectBox(targetVC: self, location: location, style: .bookmarked) { [weak self] row in
    guard let self = self else { return }

    if row == 0 {
        self.showBottomSheet(index: index)
    }
            
    if row == 1 {
        print("TODO: - Copy Link to be call")
    }
            
    if row == 2 {
        print("TODO: - Delete Bookmark API to be call")
    }
}
~~~

## 🔍 Code Review
북마크 하기, 수정하기, 삭제하기 등 SelectBox에서 처리해야할 이벤트에 필요한 정보가 더 있을 것 같아 최대한 본래 호출했던 VC에서 이벤트를 처리하면 편할 것 같아서 위와 같은 방식으로 구현해봤는데, 혹시 다른 의견이나 방법 생각나는거 있으시면 말씀주세용 🤗

## 📸 ScreenShot
<img src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/51712973/f6eec268-8580-4863-a6d6-79cef0365348" width="300px" />

### 연결된 이슈 Close
close #29 
