### PR TITLE
Fix/#68 로그인 화면에서 다음 화면 전환 오류 수정

### DIFF
--- a/Reet-Place/Reet-Place/Screen/Login/ViewController/LoginVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Login/ViewController/LoginVC.swift
@@ -81,6 +81,16 @@ class LoginVC: BaseViewController {
     
     // MARK: - Functions
     
+    private func dismissVCByPresentingVC() {
+        // 특정 VC에서 띄어진 로그인 화면일 경우
+        if self.presentingViewController is BaseNavigationController {
+            self.dismissVC()
+        } else {
+            // 첫 화면이 로그인 화면일 경우
+            (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVCToHome()
+        }
+    }
+    
     private func handleAuthorizationAppleIDButtonPress() {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         
@@ -92,12 +102,6 @@ class LoginVC: BaseViewController {
         authorizationController.presentationContextProvider = self
         authorizationController.performRequests()
     }
-    
-}
-
-// MARK: - Configure
-
-extension LoginVC {
     
 }
 
@@ -161,13 +165,7 @@ extension LoginVC {
                 guard let self = self else { return }
                 
                 KeychainManager.shared.save(key: .isFirst, value: "NO")
-                // 마이페이지에서 띄어진 로그인 화면이라면
-                if self.presentingViewController is BaseNavigationController {
-                    self.dismissVC()
-                } else {
-                    // 온보딩, 최초 실행 이후의 첫 화면이 로그인 화면일 경우라면
-                    (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVCToHome()
-                }
+                dismissVCByPresentingVC()
             })
             .disposed(by: bag)
     }
@@ -186,7 +184,7 @@ extension LoginVC {
                 
                 if isLoginSucess {
                     self.delegateLogin?.loginSuccess()
-                    self.dismissVC()
+                    dismissVCByPresentingVC()
                 } else {
                     self.showErrorAlert("LoginFailMessage".localized)
                 }

--- a/Reet-Place/Reet-Place/Screen/Login/ViewController/LoginVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Login/ViewController/LoginVC.swift
@@ -157,9 +157,17 @@ extension LoginVC {
             .disposed(by: bag)
         
         loginLaterButton.rx.tap
-            .bind(onNext: { _ in
+            .bind(onNext: { [weak self] in
+                guard let self = self else { return }
+                
                 KeychainManager.shared.save(key: .isFirst, value: "NO")
-                (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVCToHome()
+                // 마이페이지에서 띄어진 로그인 화면이라면
+                if self.presentingViewController is BaseNavigationController {
+                    self.dismissVC()
+                } else {
+                    // 온보딩, 최초 실행 이후의 첫 화면이 로그인 화면일 경우라면
+                    (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVCToHome()
+                }
             })
             .disposed(by: bag)
     }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
- 로그인 화면에서 다음에 로그인 하기 버튼 클릭시 화면이 어색하게 전환되는 문제(마이페이지에서 띄어진 로그인 화면 이후 홈으로 가능 문제 등) 수정
- 로그인 성공 시 화면이 전환되지 않는 문제 수정

## 📋 변경 사항

## 🔍 Code Review

## 📸 ScreenShot
https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/26570294/88f45332-9304-47d3-a3e1-402e00a70d4a

### 연결된 이슈 Close
close #68 
