### PR TITLE
Feat/#75 북마크 탭 바텀시트 서버 연결

### DIFF
--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		0E5A514229F6721900C44701 /* ServicePolicyVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5A514129F6721900C44701 /* ServicePolicyVC.swift */; };
 		0E5A514429F6722700C44701 /* PrivacyPolicyVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5A514329F6722700C44701 /* PrivacyPolicyVC.swift */; };
 		0E5A514629F675F300C44701 /* DeleteAccountVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5A514529F675F300C44701 /* DeleteAccountVC.swift */; };
+		0E5AF36B2B1B829C003E7223 /* BookmarkBottomSheetVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5AF36A2B1B829C003E7223 /* BookmarkBottomSheetVM.swift */; };
 		0E67036A29A201F400A5456E /* BookmarkFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E67036929A201F400A5456E /* BookmarkFilterView.swift */; };
 		0E67036E29A3CBBC00A5456E /* ReetFAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E67036D29A3CBBC00A5456E /* ReetFAB.swift */; };
 		0E8CA698299FC63300F98C15 /* BookmarkAllVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8CA697299FC63300F98C15 /* BookmarkAllVC.swift */; };
@@ -222,6 +223,7 @@
 		0E5A514129F6721900C44701 /* ServicePolicyVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicePolicyVC.swift; sourceTree = "<group>"; };
 		0E5A514329F6722700C44701 /* PrivacyPolicyVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyVC.swift; sourceTree = "<group>"; };
 		0E5A514529F675F300C44701 /* DeleteAccountVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountVC.swift; sourceTree = "<group>"; };
+		0E5AF36A2B1B829C003E7223 /* BookmarkBottomSheetVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkBottomSheetVM.swift; sourceTree = "<group>"; };
 		0E67036929A201F400A5456E /* BookmarkFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFilterView.swift; sourceTree = "<group>"; };
 		0E67036D29A3CBBC00A5456E /* ReetFAB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetFAB.swift; sourceTree = "<group>"; };
 		0E8CA697299FC63300F98C15 /* BookmarkAllVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkAllVC.swift; sourceTree = "<group>"; };
@@ -485,6 +487,7 @@
 			children = (
 				0EAD37D929E6F13600C3EA38 /* BookmarkVM.swift */,
 				0EA432E229A113CE00C4D47F /* BookmarkCardListVM.swift */,
+				0E5AF36A2B1B829C003E7223 /* BookmarkBottomSheetVM.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1400,6 +1403,7 @@
 				0EFE7C3C29ABBC870051E72D /* SelectTypeButton.swift in Sources */,
 				0E05F0032A4D8707008A20F4 /* FirstTypeOnboardingView.swift in Sources */,
 				A4EFC09E299E6F0100B066AF /* DefaultCategoryTVC.swift in Sources */,
+				0E5AF36B2B1B829C003E7223 /* BookmarkBottomSheetVM.swift in Sources */,
 				A4EFC08D299E48AD00B066AF /* MyPageVM.swift in Sources */,
 				3C9256802A1CE5B00011B093 /* CategoryDetailCultureList.swift in Sources */,
 				3CFBC6FB2A6134C300540C7F /* SearchPlaceListResponseModel.swift in Sources */,

--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0E5A514429F6722700C44701 /* PrivacyPolicyVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5A514329F6722700C44701 /* PrivacyPolicyVC.swift */; };
 		0E5A514629F675F300C44701 /* DeleteAccountVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5A514529F675F300C44701 /* DeleteAccountVC.swift */; };
 		0E5AF36B2B1B829C003E7223 /* BookmarkBottomSheetVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5AF36A2B1B829C003E7223 /* BookmarkBottomSheetVM.swift */; };
+		0E5AF36D2B1B8CEF003E7223 /* BookmarkModifyRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5AF36C2B1B8CEF003E7223 /* BookmarkModifyRequestModel.swift */; };
 		0E67036A29A201F400A5456E /* BookmarkFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E67036929A201F400A5456E /* BookmarkFilterView.swift */; };
 		0E67036E29A3CBBC00A5456E /* ReetFAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E67036D29A3CBBC00A5456E /* ReetFAB.swift */; };
 		0E8CA698299FC63300F98C15 /* BookmarkAllVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8CA697299FC63300F98C15 /* BookmarkAllVC.swift */; };
@@ -224,6 +225,7 @@
 		0E5A514329F6722700C44701 /* PrivacyPolicyVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyVC.swift; sourceTree = "<group>"; };
 		0E5A514529F675F300C44701 /* DeleteAccountVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountVC.swift; sourceTree = "<group>"; };
 		0E5AF36A2B1B829C003E7223 /* BookmarkBottomSheetVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkBottomSheetVM.swift; sourceTree = "<group>"; };
+		0E5AF36C2B1B8CEF003E7223 /* BookmarkModifyRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkModifyRequestModel.swift; sourceTree = "<group>"; };
 		0E67036929A201F400A5456E /* BookmarkFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFilterView.swift; sourceTree = "<group>"; };
 		0E67036D29A3CBBC00A5456E /* ReetFAB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetFAB.swift; sourceTree = "<group>"; };
 		0E8CA697299FC63300F98C15 /* BookmarkAllVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkAllVC.swift; sourceTree = "<group>"; };
@@ -478,6 +480,7 @@
 				0E502B702A91968A002C71F2 /* BookmarkListRequestModel.swift */,
 				0E502B782A919DEE002C71F2 /* BookmarkCountResponseModel.swift */,
 				0E502B722A9197BB002C71F2 /* BookmarkListResponseModel.swift */,
+				0E5AF36C2B1B8CEF003E7223 /* BookmarkModifyRequestModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1402,6 +1405,7 @@
 				0E05EFFC2A492CA9008A20F4 /* SelectBoxStyle.swift in Sources */,
 				0EFE7C3C29ABBC870051E72D /* SelectTypeButton.swift in Sources */,
 				0E05F0032A4D8707008A20F4 /* FirstTypeOnboardingView.swift in Sources */,
+				0E5AF36D2B1B8CEF003E7223 /* BookmarkModifyRequestModel.swift in Sources */,
 				A4EFC09E299E6F0100B066AF /* DefaultCategoryTVC.swift in Sources */,
 				0E5AF36B2B1B829C003E7223 /* BookmarkBottomSheetVM.swift in Sources */,
 				A4EFC08D299E48AD00B066AF /* MyPageVM.swift in Sources */,

--- a/Reet-Place/Reet-Place/Global/Enum/BookmarkSearchType.swift
+++ b/Reet-Place/Reet-Place/Global/Enum/BookmarkSearchType.swift
@@ -10,5 +10,5 @@ import Foundation
 enum BookmarkSearchType: String {
     case `all` = "ALL"
     case want = "WANT"
-    case gone = "GONE"
+    case done = "DONE"
 }

--- a/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkCardModel.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkCardModel.swift
@@ -15,7 +15,7 @@ struct BookmarkCardModel {
     let starCount: Int
     let address: String
     let groupType: String
-    let withPeople: String
+    let withPeople: String?
     let relLink1: String?
     let relLink2: String?
     let relLink3: String?

--- a/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkModifyRequestModel.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkModifyRequestModel.swift
@@ -1,0 +1,36 @@
+//
+//  BookmarkModifyRequestModel.swift
+//  Reet-Place
+//
+//  Created by 김태현 on 12/3/23.
+//
+
+import Foundation
+import Alamofire
+
+struct BookmarkModifyRequestModel: Encodable {
+    let type: String
+    let rate: Int
+    let people: String?
+    let relLink1: String?
+    let relLink2: String?
+    let relLink3: String?
+}
+
+// MARK: - Parameters
+
+extension BookmarkModifyRequestModel {
+    var parameter: Parameters {
+        var base: [String: Any] = [
+            "type": type,
+            "rate": rate
+        ]
+        
+        if let people, !people.isEmpty { base.updateValue(people, forKey: "people") }
+        if let relLink1, !relLink1.isEmpty { base.updateValue(relLink1, forKey: "relLink1") }
+        if let relLink2, !relLink2.isEmpty { base.updateValue(relLink2, forKey: "relLink2") }
+        if let relLink3, !relLink3.isEmpty { base.updateValue(relLink3, forKey: "relLink3") }
+        
+        return base
+    }
+}

--- a/Reet-Place/Reet-Place/Screen/BookMark/View/BookmarkBottomSheet/SelectTypeButton.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/View/BookmarkBottomSheet/SelectTypeButton.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Then
 
-protocol TypeSelectAction {
+protocol TypeSelectAction: AnyObject {
     func typeChange(type: Int)
 }
 
@@ -40,9 +40,13 @@ class SelectTypeButton: BaseView {
     
     // MARK: - Variables and Properties
     
-    var selectedTag: Int = 1
+    private var selectedTag: Int = 1
     
-    var delegate: TypeSelectAction?
+    weak var delegate: TypeSelectAction?
+    
+    var selectedType: BookmarkSearchType {
+        selectedTag == 1 ? .want : .done
+    }
     
     
     // MARK: - Life Cycle

--- a/Reet-Place/Reet-Place/Screen/BookMark/View/BookmarkBottomSheet/StarToggleButton.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/View/BookmarkBottomSheet/StarToggleButton.swift
@@ -9,11 +9,11 @@ import UIKit
 import SnapKit
 import Then
 
-class StarToggleButton: BaseView {
+final class StarToggleButton: BaseView {
     
     // MARK: - UI components
     
-    let stackView = UIStackView()
+    private let stackView = UIStackView()
         .then {
             $0.spacing = 0.0
             $0.distribution = .fillEqually
@@ -21,13 +21,13 @@ class StarToggleButton: BaseView {
             $0.axis = .horizontal
         }
     
-    let oneStarBtn = UIButton()
+    private let oneStarBtn = UIButton()
         .then {
             $0.tag = 1
             $0.setTitle("★", for: .normal)
         }
     
-    let twoStarBtn = UIButton()
+    private let twoStarBtn = UIButton()
         .then {
             $0.tag = 2
             $0.layer.borderColor = AssetColors.gray300.cgColor
@@ -35,7 +35,7 @@ class StarToggleButton: BaseView {
             $0.setTitle("★★", for: .normal)
         }
     
-    let threeStarBtn = UIButton()
+    private let threeStarBtn = UIButton()
         .then {
             $0.tag = 3
             $0.setTitle("★★★", for: .normal)
@@ -44,7 +44,7 @@ class StarToggleButton: BaseView {
     
     // MARK: - Variables and Properties
     
-    var selectedTag: Int = 1
+    private(set) var selectedStarCount: Int = 1
     
     
     // MARK: - Life Cycle
@@ -70,7 +70,7 @@ class StarToggleButton: BaseView {
             $0.isSelected = false
         }
         
-        selectedTag = sender.tag
+        selectedStarCount = sender.tag
         
         switch sender.tag {
         case 1:
@@ -84,6 +84,21 @@ class StarToggleButton: BaseView {
         }
     }
     
+    func setStarCount(_ count: Int) {
+        var starCount = 1
+        if count > 3 { starCount = 3 }
+        selectedStarCount = starCount
+        switch starCount {
+        case 1:
+            oneStarBtn.isSelected = true
+        case 2:
+            twoStarBtn.isSelected = true
+        case 3:
+            threeStarBtn.isSelected = true
+        default:
+            threeStarBtn.isSelected = true
+        }
+    }
     
 }
 

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
@@ -37,7 +37,7 @@ class BookmarkAllVC: BaseNavigationViewController {
     
     // MARK: - Variables and Properties
     
-    private let viewModel: BookmarkCardListVM = BookmarkCardListVM()
+    private let viewModel: BookmarkCardListVM = BookmarkCardListVM(type: .all)
     
     
     // MARK: - Life Cycle
@@ -224,10 +224,17 @@ extension BookmarkAllVC: BookmarkCardAction {
         let cardInfo = viewModel.output.bookmarkList.value[index]
         bottomSheetVC.configureSheetData(with: cardInfo)
         
-        bottomSheetVC.deletedBookmark
+        bottomSheetVC.deletedBookmarkId
             .withUnretained(self)
             .subscribe { owner, id in
                 owner.viewModel.deleteBookmark(id: id)
+            }
+            .disposed(by: bag)
+        
+        bottomSheetVC.modifiedBookmarkInfo
+            .withUnretained(self)
+            .subscribe { owner, bookmarkInfo in
+                owner.viewModel.modifyBookmark(info: bookmarkInfo)
             }
             .disposed(by: bag)
                 

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
@@ -223,6 +223,13 @@ extension BookmarkAllVC: BookmarkCardAction {
         let bottomSheetVC = BookmarkBottomSheetVC()
         let cardInfo = viewModel.output.bookmarkList.value[index]
         bottomSheetVC.configureSheetData(with: cardInfo)
+        
+        bottomSheetVC.deletedBookmark
+            .withUnretained(self)
+            .subscribe { owner, id in
+                owner.viewModel.deleteBookmark(id: id)
+            }
+            .disposed(by: bag)
                 
         bottomSheetVC.modalPresentationStyle = .overFullScreen
         present(bottomSheetVC, animated: false)

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
@@ -148,7 +148,7 @@ class BookmarkBottomSheetVC: ReetBottomSheet {
     
     private var bottomSheetData: BookmarkCardModel?
     
-    let deletedBookmark: PublishSubject<Int> = .init()
+    let deletedBookmarkId: PublishSubject<Int> = .init()
     
     
     // MARK: - Life Cycle
@@ -362,7 +362,7 @@ extension BookmarkBottomSheetVC {
             .subscribe { owner, _ in
                 guard let id = owner.bottomSheetData?.id else { return }
                 owner.dismissBottomSheet()
-                owner.deletedBookmark.onNext(id)
+                owner.deletedBookmarkId.onNext(id)
             }
             .disposed(by: bag)
     }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
@@ -226,7 +226,14 @@ extension BookmarkHistoryVC: BookmarkCardAction {
         let bottomSheetVC = BookmarkBottomSheetVC()
         let cardInfo = viewModel.output.bookmarkList.value[index]
         bottomSheetVC.configureSheetData(with: cardInfo)
-                
+        
+        bottomSheetVC.deletedBookmark
+            .withUnretained(self)
+            .subscribe { owner, id in
+                owner.viewModel.deleteBookmark(id: id)
+            }
+            .disposed(by: bag)
+        
         bottomSheetVC.modalPresentationStyle = .overFullScreen
         present(bottomSheetVC, animated: false)
     }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
@@ -39,7 +39,7 @@ class BookmarkHistoryVC: BaseNavigationViewController {
     
     // MARK: - Variables and Properties
     
-    private let viewModel: BookmarkCardListVM = BookmarkCardListVM()
+    private let viewModel: BookmarkCardListVM = BookmarkCardListVM(type: .done)
     
     
     // MARK: - Life Cycle
@@ -52,7 +52,7 @@ class BookmarkHistoryVC: BaseNavigationViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        viewModel.getBookmarkList(type: .gone)
+        viewModel.getBookmarkList(type: .done)
     }
     
     override func configureView() {
@@ -156,7 +156,7 @@ extension BookmarkHistoryVC: UITableViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if tableView.contentOffset.y > tableView.contentSize.height - tableView.bounds.size.height {
             if !viewModel.output.isPaging.value && !viewModel.output.isLastPage.value {
-                viewModel.getBookmarkList(type: .gone)
+                viewModel.getBookmarkList(type: .done)
             }
         }
     }
@@ -227,10 +227,17 @@ extension BookmarkHistoryVC: BookmarkCardAction {
         let cardInfo = viewModel.output.bookmarkList.value[index]
         bottomSheetVC.configureSheetData(with: cardInfo)
         
-        bottomSheetVC.deletedBookmark
+        bottomSheetVC.deletedBookmarkId
             .withUnretained(self)
             .subscribe { owner, id in
                 owner.viewModel.deleteBookmark(id: id)
+            }
+            .disposed(by: bag)
+        
+        bottomSheetVC.modifiedBookmarkInfo
+            .withUnretained(self)
+            .subscribe { owner, bookmarkInfo in
+                owner.viewModel.modifyBookmark(info: bookmarkInfo)
             }
             .disposed(by: bag)
         

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
@@ -225,6 +225,13 @@ extension BookmarkWishlistVC: BookmarkCardAction {
         let bottomSheetVC = BookmarkBottomSheetVC()
         let cardInfo = viewModel.output.bookmarkList.value[index]
         bottomSheetVC.configureSheetData(with: cardInfo)
+        
+        bottomSheetVC.deletedBookmark
+            .withUnretained(self)
+            .subscribe { owner, id in
+                owner.viewModel.deleteBookmark(id: id)
+            }
+            .disposed(by: bag)
                 
         bottomSheetVC.modalPresentationStyle = .overFullScreen
         present(bottomSheetVC, animated: false)

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
@@ -39,7 +39,7 @@ class BookmarkWishlistVC: BaseNavigationViewController {
     
     // MARK: - Variables and Properties
     
-    private let viewModel: BookmarkCardListVM = BookmarkCardListVM()
+    private let viewModel: BookmarkCardListVM = BookmarkCardListVM(type: .want)
     
     
     // MARK: - Life Cycle
@@ -226,10 +226,17 @@ extension BookmarkWishlistVC: BookmarkCardAction {
         let cardInfo = viewModel.output.bookmarkList.value[index]
         bottomSheetVC.configureSheetData(with: cardInfo)
         
-        bottomSheetVC.deletedBookmark
+        bottomSheetVC.deletedBookmarkId
             .withUnretained(self)
             .subscribe { owner, id in
                 owner.viewModel.deleteBookmark(id: id)
+            }
+            .disposed(by: bag)
+        
+        bottomSheetVC.modifiedBookmarkInfo
+            .withUnretained(self)
+            .subscribe { owner, bookmarkInfo in
+                owner.viewModel.modifyBookmark(info: bookmarkInfo)
             }
             .disposed(by: bag)
                 

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewModel/BookmarkBottomSheetVM.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewModel/BookmarkBottomSheetVM.swift
@@ -1,0 +1,111 @@
+//
+//  BookmarkBottomSheetVM.swift
+//  Reet-Place
+//
+//  Created by 김태현 on 12/3/23.
+//
+
+import Foundation
+
+import RxCocoa
+import RxSwift
+import Alamofire
+
+final class BookmarkBottomSheetVM: BaseViewModel {
+    
+    // MARK: - Variables and Properties
+    
+    var input = Input()
+    var output = Output()
+    
+    var apiSession: APIService = APISession()
+    let apiError = PublishSubject<APIError>()
+    
+    var bag = DisposeBag()
+    
+    struct Input {}
+    struct Output {
+        var isSuccessDelete: PublishSubject<Bool> = .init()
+    }
+    
+    // MARK: - Life Cycle
+    
+    init() {
+        bindInput()
+        bindOutput()
+    }
+    
+    deinit {
+        bag = DisposeBag()
+    }
+    
+}
+
+
+// MARK: - Input
+
+extension BookmarkBottomSheetVM {
+    func bindInput() {}
+}
+
+// MARK: - Output
+
+extension BookmarkBottomSheetVM {
+    func bindOutput() {}
+}
+
+// MARK: - Networking
+
+extension BookmarkBottomSheetVM {
+    
+    func deleteBookmark(id: Int) {
+        let path = "/api/bookmarks/\(id)"
+        let resource = URLResource<EmptyEntity>(path: path)
+        
+        requestDeleteBookmark(urlResource: resource)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, result in
+                switch result {
+                case .success:
+                    owner.output.isSuccessDelete.onNext(true)
+                case .failure(let error):
+                    print(error)
+                    owner.apiError.onNext(error)
+                }
+            })
+            .disposed(by: bag)
+    }
+    
+    /// 릿플 서버에 해당 북마크 취소 요청
+    private func requestDeleteBookmark<T: Decodable>(urlResource: URLResource<T>) -> Observable<Result<T, APIError>> {
+        Observable<Result<T, APIError>>.create { observer in
+            var headers = HTTPHeaders()
+            headers.add(.accept("*/*"))
+            headers.add(.contentType("application/json"))
+            
+            let task = AF.request(urlResource.resultURL,
+                                  method: .delete,
+                                  encoding: JSONEncoding.default,
+                                  headers: headers,
+                                  interceptor: AuthInterceptor())
+                .validate(statusCode: 200...399)
+                .responseDecodable(of: T.self) { response in
+                    debugPrint(response)
+                    switch response.result {
+                    case .success(let data):
+                        observer.onNext(.success(data))
+                        
+                    case .failure(let error):
+                        dump(error)
+                        guard let error = response.response else { return }
+                        observer.onNext(urlResource.judgeError(statusCode: error.statusCode))
+                    }
+                }
+            
+            return Disposables.create {
+                task.cancel()
+            }
+        }
+    }
+    
+}

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewModel/BookmarkCardListVM.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewModel/BookmarkCardListVM.swift
@@ -65,6 +65,17 @@ extension BookmarkCardListVM: Output {
     
 }
 
+// MARK: - Functions
+
+extension BookmarkCardListVM {
+    
+    func deleteBookmark(id: Int) {
+        let originBookmarkList = output.bookmarkList.value
+        let deletedBookmarkList = originBookmarkList.filter({ $0.id != id })
+        output.bookmarkList.accept(deletedBookmarkList)
+    }
+    
+}
 
 // MARK: - Networking
 

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewModel/BookmarkCardListVM.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewModel/BookmarkCardListVM.swift
@@ -18,6 +18,7 @@ final class BookmarkCardListVM: BaseViewModel {
     
     var apiSession: APIService = APISession()
     let apiError = PublishSubject<APIError>()
+    private let type: BookmarkSearchType
     
     var bag = DisposeBag()
     
@@ -32,7 +33,9 @@ final class BookmarkCardListVM: BaseViewModel {
         var isLastPage: BehaviorRelay<Bool> = BehaviorRelay(value: false)
     }
     
-    init() {
+    init(type: BookmarkSearchType) {
+        self.type = type
+        
         bindInput()
         bindOutput()
     }
@@ -75,6 +78,23 @@ extension BookmarkCardListVM {
         output.bookmarkList.accept(deletedBookmarkList)
     }
     
+    func modifyBookmark(info: BookmarkInfo) {
+        let card = info.toBookmarkCardModel()
+        var currentBookmarkList = output.bookmarkList.value
+        switch type {
+        case .all:
+            currentBookmarkList = currentBookmarkList.map { $0.id == card.id ? card : $0 }
+        case .want, .done:
+            if type.rawValue == card.groupType {
+                currentBookmarkList = currentBookmarkList.map { $0.id == card.id ? card : $0 }
+            } else {
+                currentBookmarkList = currentBookmarkList.filter { $0.id != card.id }
+                
+            }
+        }
+        output.bookmarkList.accept(currentBookmarkList)
+    }
+    
 }
 
 // MARK: - Networking
@@ -83,7 +103,7 @@ extension BookmarkCardListVM {
     
     func getBookmarkList(type: BookmarkSearchType) {
         let page = input.page.value
-        let path = "/api/bookmarks?searchType=\(type.rawValue)&page=\(page)&size=20&sort=LATEST"
+        let path = "/api/bookmarks?searchType=\(type.rawValue)&page=\(page)&size=10&sort=LATEST"
         let resource = URLResource<BookmarkListResponseModel>(path: path)
         
         output.isPaging.accept(true)

--- a/Reet-Place/Reet-Place/Screen/Shared/View/PlaceInfoView.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/PlaceInfoView.swift
@@ -162,7 +162,7 @@ class PlaceInfoView: BaseView {
         switch cardInfo.groupType {
         case "WANT":
             groupIconImage = AssetsImages.cardWishChip20
-        case "GONE":
+        case "DONE":
             groupIconImage = AssetsImages.cardHistoryChip20
         default:
             groupIconImage = nil

--- a/Reet-Place/Reet-Place/Screen/Shared/View/PlaceInfoView.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/PlaceInfoView.swift
@@ -199,8 +199,8 @@ class PlaceInfoView: BaseView {
         isExpandMoreImageView(expand: !cardInfo.infoHidden)
         
         // 함께할 사람들
-        if !cardInfo.withPeople.isEmpty {
-            withPeopleView.peopleLabel.text = cardInfo.withPeople
+        if let withPeople = cardInfo.withPeople {
+            withPeopleView.peopleLabel.text = withPeople
             withPeopleLabel.isHidden = false
             withPeopleView.isHidden = false
         }

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetPopUp/ReetPopUp.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetPopUp/ReetPopUp.swift
@@ -205,6 +205,12 @@ extension ReetPopUp {
             })
             .disposed(by: bag)
         
+        confirmBtn.rx.tap
+            .withUnretained(self)
+            .bind(onNext: { owner, _ in
+                owner.dismiss(animated: false)
+            })
+            .disposed(by: bag)
     }
     
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
- 북마크 탭 바텀시트 -> 수정, 삭제 연결

## 📋 변경 사항
### 1. 북마크 탭 바텀시트 서버 연결
- 북마크 탭에서 바텀시트를 통해 북마크 정보를 수정, 삭제하는 기능 서버 연결 완료했습니다~!
- 바텀시트에서 수정하거나 삭제했을 시 기존의 북마크 리스트에도 변경이 반영되어야 하는데, 이 부분은 따로 서버에서 다시 리스트를 받아오지 않고, 수정이나 삭제에 성공했다면 북마크의 id 값을 이용해서 리스트를 클라이언트 단에서 수정해주었습니다!
- 북마크 삭제 -> 성공 응답 -> VC에서 감지(바인딩) -> 리스트에서 삭제
- 북마크 수정 -> 수정 성공 응답 -> VC에서 감지(바인딩) -> 리스트에서 삭제 또는 수정
- 위와 같은 플로우로 진행됩니당

### 2. 다녀왔어요 GONE? DONE?
- 슬랙에도 백엔드분들께 여쭤보긴했는데 다녀왔어요의 필드 값이 GONE, DONE 둘 중 모호한 문제가 있어서 현재 다녀왔어요 리스트 불러오는게 안됩니당
- 전체보기, 가고싶어요는 정상 작동하고, 일단 필드 값은 DONE으로 변경해두었습니다 :)

### 3. Nullable 필드 수정
- 함께한 사람 필드 또한 nullable하기 때문에 optional로 변경해주었습니다

## 🔍 Code Review
현재 VM에서 직접 네트워크 통신하는 부분이 곳곳에 있는데 아무래도 리팩토링이 필요할 것 같습니다 😅😅
마찬가지로 제가 예전에 짰던 코드들 보는데 진짜 엉망이네요,,, 아마 앞으로 PR 중간 중간에 코드 수정이 있을 듯 합니다,, ㅋㅋㅋ

## 📸 ScreenShot
https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/51712973/98a60f70-1c9d-433b-851d-0d44f02f0e8b


### 연결된 이슈 Close
close #75 
