### PR TITLE
Feat/#72 북마크탭 지도로 보기 연결

### DIFF
--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		0E05F0012A4C7DE5008A20F4 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E05F0002A4C7DE5008A20F4 /* OnboardingView.swift */; };
 		0E05F0032A4D8707008A20F4 /* FirstTypeOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E05F0022A4D8707008A20F4 /* FirstTypeOnboardingView.swift */; };
 		0E05F0052A4D8787008A20F4 /* OtherTypeOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E05F0042A4D8787008A20F4 /* OtherTypeOnboardingView.swift */; };
+		0E1B62CD2B315AB900C1E609 /* BookmarkSummaryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E1B62CC2B315AB900C1E609 /* BookmarkSummaryModel.swift */; };
+		0E1B62CF2B315AD000C1E609 /* BookmarkSummaryResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E1B62CE2B315AD000C1E609 /* BookmarkSummaryResponseModel.swift */; };
 		0E2D6F2A29EBBB7D0053CD90 /* BookmarkMainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2D6F2929EBBB7D0053CD90 /* BookmarkMainModel.swift */; };
 		0E2D6F2C29EBBD180053CD90 /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2D6F2B29EBBD180053CD90 /* UIImageView+.swift */; };
 		0E2D6F5429F140A80053CD90 /* ReetPopUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2D6F5329F140A80053CD90 /* ReetPopUp.swift */; };
@@ -45,6 +47,8 @@
 		0EAFCFDC2A2888700023A738 /* SelectBoxTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EAFCFDB2A2888700023A738 /* SelectBoxTVC.swift */; };
 		0EB8D81229FF8C0E00E79BA4 /* PopUpType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB8D81129FF8C0E00E79BA4 /* PopUpType.swift */; };
 		0EB8D81429FFFF9D00E79BA4 /* AccountDeletedVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB8D81329FFFF9D00E79BA4 /* AccountDeletedVC.swift */; };
+		0EDD36B12B29FB8400D44F06 /* BookmarkMapVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDD36B02B29FB8400D44F06 /* BookmarkMapVC.swift */; };
+		0EDD36B32B29FDEA00D44F06 /* BookmarkMapVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDD36B22B29FDEA00D44F06 /* BookmarkMapVM.swift */; };
 		0EED226B29F8C77900C8102E /* DeleteAccountVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EED226A29F8C77900C8102E /* DeleteAccountVM.swift */; };
 		0EED227129F8CB6800C8102E /* CheckboxButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EED227029F8CB6800C8102E /* CheckboxButton.swift */; };
 		0EFE7C3629AA46CA0051E72D /* ReetBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFE7C3529AA46CA0051E72D /* ReetBottomSheet.swift */; };
@@ -212,6 +216,8 @@
 		0E05F0022A4D8707008A20F4 /* FirstTypeOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstTypeOnboardingView.swift; sourceTree = "<group>"; };
 		0E05F0042A4D8787008A20F4 /* OtherTypeOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherTypeOnboardingView.swift; sourceTree = "<group>"; };
 		0E05F0062A4F10F1008A20F4 /* Reet-PlaceDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Reet-PlaceDebug.entitlements"; sourceTree = "<group>"; };
+		0E1B62CC2B315AB900C1E609 /* BookmarkSummaryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkSummaryModel.swift; sourceTree = "<group>"; };
+		0E1B62CE2B315AD000C1E609 /* BookmarkSummaryResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkSummaryResponseModel.swift; sourceTree = "<group>"; };
 		0E2D6F2929EBBB7D0053CD90 /* BookmarkMainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkMainModel.swift; sourceTree = "<group>"; };
 		0E2D6F2B29EBBD180053CD90 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		0E2D6F5329F140A80053CD90 /* ReetPopUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetPopUp.swift; sourceTree = "<group>"; };
@@ -245,6 +251,8 @@
 		0EAFCFDB2A2888700023A738 /* SelectBoxTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectBoxTVC.swift; sourceTree = "<group>"; };
 		0EB8D81129FF8C0E00E79BA4 /* PopUpType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpType.swift; sourceTree = "<group>"; };
 		0EB8D81329FFFF9D00E79BA4 /* AccountDeletedVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeletedVC.swift; sourceTree = "<group>"; };
+		0EDD36B02B29FB8400D44F06 /* BookmarkMapVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkMapVC.swift; sourceTree = "<group>"; };
+		0EDD36B22B29FDEA00D44F06 /* BookmarkMapVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkMapVM.swift; sourceTree = "<group>"; };
 		0EED226A29F8C77900C8102E /* DeleteAccountVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountVM.swift; sourceTree = "<group>"; };
 		0EED227029F8CB6800C8102E /* CheckboxButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckboxButton.swift; sourceTree = "<group>"; };
 		0EFE7C3529AA46CA0051E72D /* ReetBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetBottomSheet.swift; sourceTree = "<group>"; };
@@ -481,6 +489,8 @@
 				0E502B782A919DEE002C71F2 /* BookmarkCountResponseModel.swift */,
 				0E502B722A9197BB002C71F2 /* BookmarkListResponseModel.swift */,
 				0E5AF36C2B1B8CEF003E7223 /* BookmarkModifyRequestModel.swift */,
+				0E1B62CC2B315AB900C1E609 /* BookmarkSummaryModel.swift */,
+				0E1B62CE2B315AD000C1E609 /* BookmarkSummaryResponseModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -491,6 +501,7 @@
 				0EAD37D929E6F13600C3EA38 /* BookmarkVM.swift */,
 				0EA432E229A113CE00C4D47F /* BookmarkCardListVM.swift */,
 				0E5AF36A2B1B829C003E7223 /* BookmarkBottomSheetVM.swift */,
+				0EDD36B22B29FDEA00D44F06 /* BookmarkMapVM.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -752,6 +763,7 @@
 		3C2AEF572990CAB200E36342 /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
+				0EDD36B02B29FB8400D44F06 /* BookmarkMapVC.swift */,
 				3C2AF0D02990DFAC00E36342 /* BookmarkVC.swift */,
 				0E8CA697299FC63300F98C15 /* BookmarkAllVC.swift */,
 				0EA432D829A0894400C4D47F /* BookmarkWishlistVC.swift */,
@@ -1397,6 +1409,7 @@
 				3C4DA53F2A56518900274692 /* LoginVC.swift in Sources */,
 				0E2D6F2A29EBBB7D0053CD90 /* BookmarkMainModel.swift in Sources */,
 				3C2784162A0A652E0095B706 /* ReetMenuTarBarCVC.swift.swift in Sources */,
+				0E1B62CD2B315AB900C1E609 /* BookmarkSummaryModel.swift in Sources */,
 				A4AABE6F299BC0D400BA9D37 /* AssetFonts.swift in Sources */,
 				3C09F6962A5E5B2000B6B0BF /* UpdateTokenResponseModel.swift in Sources */,
 				3CE3C47B2A458A180097FB63 /* SearchHistoryTVC.swift in Sources */,
@@ -1463,6 +1476,7 @@
 				3C04A7C32A4C072B00A31FA3 /* PlaceInfoView.swift in Sources */,
 				A4917E022996A4D300DF2A65 /* AssetColors.swift in Sources */,
 				3C09F69A2A5F936600B6B0BF /* EmptyEntity.swift in Sources */,
+				0E1B62CF2B315AD000C1E609 /* BookmarkSummaryResponseModel.swift in Sources */,
 				0E502B792A919DEE002C71F2 /* BookmarkCountResponseModel.swift in Sources */,
 				A49515F129A0764400A12EE1 /* UserProfileView.swift in Sources */,
 				3C92567C2A1CE4E50011B093 /* CategoryDetailCafeDataSource.swift in Sources */,
@@ -1486,6 +1500,7 @@
 				3C423F2B29AAF649003B7B7D /* CategoryChipButton.swift in Sources */,
 				A4D09ECF299F9D10004DEE97 /* UserInfoMenu.swift in Sources */,
 				3C9256762A1CE2DF0011B093 /* CategoryDetailShoppingDataSource.swift in Sources */,
+				0EDD36B32B29FDEA00D44F06 /* BookmarkMapVM.swift in Sources */,
 				3C976C8129AA61110002F8A7 /* PlaceCategoryList.swift in Sources */,
 				3C2AED602990B3C200E36342 /* UILabel+.swift in Sources */,
 				0EA432E729A13EBE00C4D47F /* RelatedURLButton.swift in Sources */,
@@ -1505,6 +1520,7 @@
 				3C2AED5F2990B3C200E36342 /* UIViewController+.swift in Sources */,
 				3C2AF0D929913FF000E36342 /* SceneDelegate.swift in Sources */,
 				0E05F0012A4C7DE5008A20F4 /* OnboardingView.swift in Sources */,
+				0EDD36B12B29FB8400D44F06 /* BookmarkMapVC.swift in Sources */,
 				A4EFC095299E50DF00B066AF /* KeychainManager.swift in Sources */,
 				A4917E172996A8B300DF2A65 /* ButtonDisabledColorProvider.swift in Sources */,
 				3C27841D2A0A6F1B0095B706 /* TabPlaceCategoryList.swift in Sources */,

--- a/Reet-Place/Reet-Place/Global/Enum/BookmarkSearchType.swift
+++ b/Reet-Place/Reet-Place/Global/Enum/BookmarkSearchType.swift
@@ -12,3 +12,16 @@ enum BookmarkSearchType: String {
     case want = "WANT"
     case done = "DONE"
 }
+
+extension BookmarkSearchType {
+    var title: String {
+        switch self {
+        case .all:
+            return "BookmarkAll".localized
+        case .want:
+            return "BookmarkWishlist".localized
+        case .done:
+            return "BookmarkHistory".localized
+        }
+    }
+}

--- a/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkSummaryModel.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkSummaryModel.swift
@@ -1,0 +1,21 @@
+//
+//  BookmarkSummaryModel.swift
+//  Reet-Place
+//
+//  Created by 김태현 on 12/19/23.
+//
+
+import Foundation
+
+struct BookmarkSummaryModel {
+    let id: Int
+    let type: String
+    let name: String
+    let url: String
+    let category: String
+    let subCategory: String
+    let lotNumberAddress: String
+    let roadAddress: String
+    let lat: Double
+    let lng: Double
+}

--- a/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkSummaryResponseModel.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkSummaryResponseModel.swift
@@ -1,0 +1,32 @@
+//
+//  BookmarkSummaryResponseModel.swift
+//  Reet-Place
+//
+//  Created by 김태현 on 12/19/23.
+//
+
+import Foundation
+
+typealias BookmarkSummaryListResponseModel = [BookmarkSummaryResponseModel]
+
+struct BookmarkSummaryResponseModel: Decodable {
+    let id: Int
+    let place: BookmarkPlaceInfo
+    let type: String
+    let thumbnailImage: String
+    
+    func toSummary() -> BookmarkSummaryModel {
+        return .init(
+            id: id,
+            type: type,
+            name: place.name,
+            url: place.url,
+            category: place.category,
+            subCategory: place.subCategory,
+            lotNumberAddress: place.lotNumberAddress,
+            roadAddress: place.roadAddress,
+            lat: Double(place.lat) ?? 0.0,
+            lng: Double(place.lng) ?? 0.0
+        )
+    }
+}

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkAllVC.swift
@@ -68,6 +68,7 @@ class BookmarkAllVC: BaseNavigationViewController {
     override func bindInput() {
         super.bindInput()
         
+        bindButton()
     }
     
     override func bindOutput() {
@@ -124,9 +125,19 @@ extension BookmarkAllVC {
 }
 
 
-// MARK: - Output
+// MARK: - Bind
 
 extension BookmarkAllVC {
+    
+    private func bindButton() {
+        viewOnMapBtn.rx.tap
+            .withUnretained(self)
+            .bind { owner, _ in
+                let bookmarkMapVC = BookmarkMapVC(bookmarkType: .all)
+                bookmarkMapVC.pushWithHidesReetPlaceTabBar()
+            }
+            .disposed(by: bag)
+    }
     
     private func bindBookmarkAll() {
         viewModel.output.bookmarkList

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkHistoryVC.swift
@@ -70,6 +70,7 @@ class BookmarkHistoryVC: BaseNavigationViewController {
     override func bindInput() {
         super.bindInput()
         
+        bindButton()
     }
     
     override func bindOutput() {
@@ -127,9 +128,19 @@ extension BookmarkHistoryVC {
 }
 
 
-// MARK: - Output
+// MARK: - Bind
 
 extension BookmarkHistoryVC {
+    
+    private func bindButton() {
+        viewOnMapBtn.rx.tap
+            .withUnretained(self)
+            .bind { owner, _ in
+                let bookmarkMapVC = BookmarkMapVC(bookmarkType: .done)
+                bookmarkMapVC.pushWithHidesReetPlaceTabBar()
+            }
+            .disposed(by: bag)
+    }
     
     private func bindBookmarkHistory() {
         viewModel.output.bookmarkList

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkMapVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkMapVC.swift
@@ -1,0 +1,170 @@
+//
+//  BookmarkMapVC.swift
+//  Reet-Place
+//
+//  Created by 김태현 on 12/13/23.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+import Then
+import SnapKit
+
+import NMapsMap
+
+final class BookmarkMapVC: BaseNavigationViewController {
+    
+    // MARK: - UI components
+    
+    private let mapView: NMFMapView = .init()
+    
+    
+    // MARK: - Variables and Properties
+    
+    private let viewModel: BookmarkMapVM = .init()
+    private let bookmarkType: BookmarkSearchType
+    private var markers: [NMFMarker] = .init()
+    
+    
+    // MARK: - Initialize
+    
+    init(bookmarkType: BookmarkSearchType) {
+        self.bookmarkType = bookmarkType
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        viewModel.getBookmarkSummaries(type: bookmarkType)
+    }
+    
+    override func configureView() {
+        super.configureView()
+        
+        configureInnerView()
+    }
+    
+    override func layoutView() {
+        super.layoutView()
+        
+        configureLayout()
+    }
+    
+    override func bindOutput() {
+        super.bindOutput()
+        
+        bindSummaries()
+    }
+    
+    // MARK: - Functions
+    
+    private func configureMarkers(from summaries: [BookmarkSummaryModel]) {
+        summaries.forEach { summary in
+            guard let bookmarkType = BookmarkType(rawValue: summary.type) else { return }
+            
+            let marker = NMFMarker()
+            marker.position = NMGLatLng(lat: summary.lat, lng: summary.lng)
+            marker.iconImage = NMFOverlayImage(image: MarkerType.round(bookmarkType.markerState).image)
+            
+            marker.touchHandler = { [weak self] (overlay: NMFOverlay) -> Bool in
+                guard let self else { return true }
+                
+                let bottomSheetVC = PlaceBottomSheet()
+                bottomSheetVC.modalPresentationStyle = .overFullScreen
+                bottomSheetVC.configurePlaceBottomSheet(
+                    placeName: summary.name,
+                    address: summary.roadAddress,
+                    category: summary.category,
+                    urlLink: summary.url,
+                    bookmarkType: bookmarkType,
+                    marker: marker
+                )
+                
+                self.present(bottomSheetVC, animated: true)
+                
+                return true
+            }
+            
+            marker.mapView = mapView
+            markers.append(marker)
+        }
+        
+        moveCameraForFitMakers()
+    }
+    
+    /// 마커가 모두 보이도록 카메라를 이동함.
+    private func moveCameraForFitMakers() {
+        guard let firstMarker = markers.first else { return }
+        let firstPosition = NMGLatLng(lat: firstMarker.position.lat, lng: firstMarker.position.lng)
+        var markersBounds = NMGLatLngBounds(southWest: firstPosition, northEast: firstPosition)
+        
+        markers.forEach { marker in
+            markersBounds = markersBounds.expand(toPoint: marker.position)
+        }
+        
+        mapView.moveCamera(NMFCameraUpdate(fit: markersBounds, padding: 50.0))
+    }
+    
+}
+
+
+// MARK: - Configure
+
+extension BookmarkMapVC {
+    
+    private func configureInnerView() {
+        title = bookmarkType.title
+        navigationBar.style = .right
+        mapView.minZoomLevel = 5.0
+        mapView.maxZoomLevel = 18.0
+        mapView.extent = NMGLatLngBounds(
+            southWestLat: 31.43,
+            southWestLng: 122.37,
+            northEastLat: 44.35,
+            northEastLng: 132
+        )
+        
+        view.addSubviews([mapView])
+    }
+    
+}
+
+
+// MARK: - Layout
+
+extension BookmarkMapVC {
+    
+    private func configureLayout() {
+        mapView.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.leading.bottom.trailing.equalTo(view)
+        }
+    }
+    
+}
+
+// MARK: - Bind
+
+extension BookmarkMapVC {
+    
+    private func bindSummaries() {
+        viewModel.output.bookmarkSummaries
+            .withUnretained(self)
+            .subscribe { owner, summaries in
+                owner.configureMarkers(from: summaries)
+            }
+            .disposed(by: bag)
+    }
+    
+}

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkVC.swift
@@ -62,7 +62,9 @@ class BookmarkVC: BaseNavigationViewController {
         super.viewDidAppear(animated)
         
         removeCache()
-        viewModel.getBookmarkCount()
+        
+        // TODO: - 서버 에러 해결 후 변경
+        viewModel.getBookmarkMock()
     }
     
     override func configureView() {

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkWishlistVC.swift
@@ -70,6 +70,7 @@ class BookmarkWishlistVC: BaseNavigationViewController {
     override func bindInput() {
         super.bindInput()
         
+        bindButton()
     }
     
     override func bindOutput() {
@@ -127,9 +128,19 @@ extension BookmarkWishlistVC {
 }
 
 
-// MARK: - Output
+// MARK: - Bind
 
 extension BookmarkWishlistVC {
+    
+    private func bindButton() {
+        viewOnMapBtn.rx.tap
+            .withUnretained(self)
+            .bind { owner, _ in
+                let bookmarkMapVC = BookmarkMapVC(bookmarkType: .want)
+                bookmarkMapVC.pushWithHidesReetPlaceTabBar()
+            }
+            .disposed(by: bag)
+    }
     
     private func bindBookmarkWishList() {
         viewModel.output.bookmarkList

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewModel/BookmarkMapVM.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewModel/BookmarkMapVM.swift
@@ -1,0 +1,77 @@
+//
+//  BookmarkMapVM.swift
+//  Reet-Place
+//
+//  Created by 김태현 on 12/13/23.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+final class BookmarkMapVM: BaseViewModel {
+    
+    // MARK: - Variables and Properties
+    
+    var input = Input()
+    var output = Output()
+    
+    var apiSession: APIService = APISession()
+    let apiError = PublishSubject<APIError>()
+    
+    var bag = DisposeBag()
+    
+    struct Input {}
+    struct Output {
+        var bookmarkSummaries: BehaviorRelay<[BookmarkSummaryModel]> = BehaviorRelay(value: [])
+    }
+    
+    // MARK: - Life Cycle
+    
+    init() {
+        bindInput()
+        bindOutput()
+    }
+    
+    deinit {
+        bag = DisposeBag()
+    }
+    
+}
+
+
+// MARK: - Input
+
+extension BookmarkMapVM {
+    func bindInput() {}
+}
+
+// MARK: - Output
+
+extension BookmarkMapVM {
+    func bindOutput() {}
+}
+
+// MARK: - Networking
+
+extension BookmarkMapVM {
+    
+    func getBookmarkSummaries(type: BookmarkSearchType) {
+        let path = "/api/bookmarks/all/summaries?searchType=\(type.rawValue)"
+        let resource = URLResource<BookmarkSummaryListResponseModel>(path: path)
+        
+        apiSession.requestGet(urlResource: resource)
+            .withUnretained(self)
+            .subscribe { owner, result in
+                switch result {
+                case .success(let summariesReponse):
+                    let summaries = summariesReponse.map { $0.toSummary() }
+                    owner.output.bookmarkSummaries.accept(summaries)
+                case .failure(let error):
+                    owner.apiError.onNext(error)
+                }
+            }
+            .disposed(by: bag)
+    }
+    
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
- 북마크탭의 "지도로 보기"를 연결했습니다.

## 📋 변경 사항
### BookmarkMapVC, VM 구현
- 지도로 보기 시에 사용되는 BookmarkMapVC와 VM을 구현했습니다.
- 지도로 보기 선택 시 BookmarkMapVC로 이동하며 VM에서 해당 타입으로 북마크 간략 정보를 조회홥니다.
- `moveCameraForFitMarkers()` 메서드를 통해 모든 마커가 한 화면에서 노출되도록 카메라 위치를 조정합니다.
- 마커가 한 위치에서만 노출될 때 지나치게 확대되거나, 축소 시 지나치게 축소되는걸 막기 위해 mapView의 `minZoomLevel`, `maxZoomLevel`, `extent`를 통해 축소, 확대 범위와 이동 범위를 제한해두었습니다. 

## 🔍 Code Review
현재 "북마크 종류 별 정보 조회" API가 동작하지 않음에 따라 해당 API 대신 Mock을 연결해둔 상태입니다!
추가로 "다녀왔어요" 부분도 DONE, GONE 문제로 정상 작동하지 않아 이동이 불가능합니다.
(백엔드 측에 공유는 되어있습니다!)

## 📸 ScreenShot

https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/51712973/faf320bd-3d85-4546-aaf2-c3154a29a5b9


### 연결된 이슈 Close
close #72 
