### PR TITLE
Fix/#91 회원 탈퇴 시 로그인 타입에 따라 identifier 재발급 처리

### DIFF
--- a/Reet-Place/Reet-Place/Global/Assets/en.lproj/Localizable.strings
+++ b/Reet-Place/Reet-Place/Global/Assets/en.lproj/Localizable.strings
@@ -153,6 +153,7 @@ No = "아니오";
 LogoutSuccess = "로그아웃 되었습니다";
 ErrorOccurred = "오류발생 😵";
 BookmarkSaved = "저장이 완료되었어요 !";
+UnlinkFailed = "회원탈퇴에 실패했어요.";
 
 // MARK: - Onboarding
 FirstOnboardingFirstLine = "어떤 상황에서든";

--- a/Reet-Place/Reet-Place/Global/Utils/KeychainManager.swift
+++ b/Reet-Place/Reet-Place/Global/Utils/KeychainManager.swift
@@ -141,7 +141,6 @@ extension KeychainManager {
       
       case appleUserAuthID
       case kakaoToken
-      case identifier
       
       case loginType
       

--- a/Reet-Place/Reet-Place/Global/Utils/KeychainManager.swift
+++ b/Reet-Place/Reet-Place/Global/Utils/KeychainManager.swift
@@ -119,8 +119,8 @@ extension KeychainManager {
     
     /// 업데이트를 통해 갱신된 토큰을 로컬에 저장
     func updateToken(updatedToken: UpdateTokenResponseModel) {
-        save(key: .accessToken, value: updatedToken.accessToken)
-        save(key: .refreshToken, value: updatedToken.refreshToken)
+        update(key: .accessToken, value: updatedToken.accessToken)
+        update(key: .refreshToken, value: updatedToken.refreshToken)
     }
     
     /// 로컬 디바이스에 저장된 사용자의 기본정보 모두 제거

--- a/Reet-Place/Reet-Place/Screen/Login/ViewModel/LoginVM.swift
+++ b/Reet-Place/Reet-Place/Screen/Login/ViewModel/LoginVM.swift
@@ -76,7 +76,6 @@ extension LoginVM {
                     KeychainManager.shared.save(key: .userName, value: data.nickname)
                     KeychainManager.shared.save(key: .memberID, value: String(data.memberID))
                     KeychainManager.shared.save(key: .loginType, value: data.loginType.lowercased())
-                    KeychainManager.shared.save(key: .identifier, value: token)
                     
                     print("\(socialType.description) 로그인 성공")
                     


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
- 회원 탈퇴 시 로그인 타입에 따라 identifier 재발급 처리를 추가했습니다~!

## 📋 변경 사항
변경 사항이나 추가 사항을 작성해주세요.
### Keychain -> identifier 제거
- QA 간 Refresh API가 여러 번 호출되는 문제의 원인이 애플 Authorization Code의 만료였습니다!
- Unlink 호출 시 서버에서 카카오 회원은 카카오 Access Token을, 애플 회원은 애플 Authorization Code를 이용해 서비스 연결을 해제하게 되는데요, 현재처럼 로그인 시에 Keychain에 저장해두게 되면 회원 탈퇴 시에는 이미 만료된 상태라 사용할 수 없는 상태가 됩니다.
- 그래서 해당 정보를 로그인 시 Keychain에 저장하는 것이 아니라, 회원 탈퇴 시에 Access Token, Authorization Code를 재발급받도록 수정했습니다!
- 카카오의 경우 Token Refresh, 애플의 경우 다시 애플 로그인을 요청해 Authorization Code를 발급받아 회원 탈퇴에 사용합니다.

## 🔍 Code Review
N/A

## 📸 ScreenShot
N/A

### 연결된 이슈 Close
close #91 
