### PR TITLE
Feat/#108 GitHub Action을 통한 Build Test 자동화

### DIFF
--- a/.github/workflows/build_test_on_develop.yml
+++ b/.github/workflows/build_test_on_develop.yml
@@ -1,0 +1,30 @@
+# This workflow will build a Swift project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
+
+name: Build Test
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+
+    runs-on: macos-13
+
+    steps:
+    - name: Code Checkout ✔️
+      uses: actions/checkout@v3
+      
+    - name: Xcode Version Settings ⚙️
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: "15.0.1"
+        
+    - name: Start Xcode build test 🏗️
+      run: |
+        cd Reet-Place
+        pod install --repo-update --clean-install
+        xcodebuild build -workspace Reet-Place.xcworkspace -scheme Reet-Place -destination 'platform=iOS Simulator,name=iPhone 11 Pro,OS=latest' CODE_SIGNING_ALLOWED=No


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
- GitHub Action을 통한 Build Test 자동화를 도입했습니다!

## 📋 변경 사항
### GitHub Action 추가
- `develop` 브랜치에 push 혹은 PR 시에 Build Test 진행하도록 GitHub Action을 추가했습니다!
- pod install -> workspace build 순으로 진행됩니당
- 추후에 현재 구현되어 있는 Fastlane을 이용해 TestFlight 배포 자동화도 연결해볼 예정임다.

## 🔍 Code Review
N/A

## 📸 ScreenShot
### 빌드 실패 시
<img width="927" alt="스크린샷 2024-01-24 오후 5 18 27" src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/51712973/439fad85-068d-46f6-8585-cb2b6e33dcd1">

### 빌드 성공 시
![스크린샷 2024-01-24 오후 8 12 28](https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/51712973/092503ab-5b91-4aae-ac53-56c32083004f)

### 연결된 이슈 Close
close #108
