### PR TITLE
Feat/#99 더보기 버튼 -> 링크복사 기능

### DIFF
--- a/Reet-Place/Reet-Place/Global/Assets/en.lproj/Localizable.strings
+++ b/Reet-Place/Reet-Place/Global/Assets/en.lproj/Localizable.strings
@@ -154,6 +154,7 @@ LogoutSuccess = "로그아웃 되었습니다";
 ErrorOccurred = "오류발생 😵";
 BookmarkSaved = "저장이 완료되었어요 !";
 UnlinkFailed = "회원탈퇴에 실패했어요.";
+LinkCopied = "링크가 복사되었어요 !";
 
 // MARK: - Onboarding
 FirstOnboardingFirstLine = "어떤 상황에서든";

--- a/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
+++ b/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
@@ -103,8 +103,12 @@ extension UIViewController {
       embededViewController.removeFromParent()
     }
       
-    /// Toast Message 노출
-    func showToast(message: String, bottomViewHeight: Double) {
+    
+    /// Toast Message를 노출합니다.
+    /// - Parameters:
+    ///   - message: 노출할 메세지
+    ///   - bottomViewHeight: Toast 메세지 아래에 추가로 View가 존재할 시 해당 View의 높이
+    func showToast(message: String, bottomViewHeight: Double = 0.0) {
         
         let toastLabel = BaseAttributedLabel(font: .body2,
                                              text: message,

--- a/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkCardModel.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkCardModel.swift
@@ -11,6 +11,7 @@ struct BookmarkCardModel {
     let id: Int
     let thumbnailImage: String?
     let placeName: String
+    let placeDetailURL: String
     let categoryName: String
     let starCount: Int
     let address: String
@@ -29,6 +30,7 @@ extension BookmarkCardModel {
             id: 0,
             thumbnailImage: nil,
             placeName: .empty,
+            placeDetailURL: .empty,
             categoryName: .empty,
             starCount: 1,
             address: .empty,

--- a/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkListResponseModel.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkListResponseModel.swift
@@ -35,6 +35,7 @@ struct BookmarkInfo: Codable {
         return .init(id: id,
                      thumbnailImage: thumbnailImage,
                      placeName: place.name,
+                     placeDetailURL: place.url,
                      categoryName: place.category,
                      starCount: rate,
                      address: place.roadAddress,

--- a/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkSummaryModel.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/Model/BookmarkSummaryModel.swift
@@ -30,6 +30,7 @@ struct BookmarkSummaryModel {
             id: id,
             thumbnailImage: thumbnailImage,
             placeName: name,
+            placeDetailURL: url,
             categoryName: category,
             starCount: rate,
             address: roadAddress,

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkBottomSheetVC.swift
@@ -227,6 +227,7 @@ class BookmarkBottomSheetVC: ReetBottomSheet {
             id: bottomSheetData.id,
             thumbnailImage: bottomSheetData.thumbnailImage,
             placeName: bottomSheetData.placeName,
+            placeDetailURL: bottomSheetData.placeDetailURL,
             categoryName: bottomSheetData.categoryName,
             starCount: starToggleBtn.selectedStarCount,
             address: bottomSheetData.address,

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkListVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkListVC.swift
@@ -242,7 +242,9 @@ extension BookmarkListVC: BookmarkCardAction {
             }
             
             if row == 1 {
-                print("TODO: - Copy Link to be call")
+                let card = self.viewModel.output.bookmarkList.value[index]
+                UIPasteboard.general.string = card.placeDetailURL
+                self.showToast(message: "LinkCopied".localized, bottomViewHeight: 0.0)
             }
             
             if row == 2 {

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkListVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkListVC.swift
@@ -244,7 +244,7 @@ extension BookmarkListVC: BookmarkCardAction {
             if row == 1 {
                 let card = self.viewModel.output.bookmarkList.value[index]
                 UIPasteboard.general.string = card.placeDetailURL
-                self.showToast(message: "LinkCopied".localized, bottomViewHeight: 0.0)
+                self.showToast(message: "LinkCopied".localized)
             }
             
             if row == 2 {

--- a/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
@@ -573,7 +573,7 @@ extension SearchVC: BookmarkCardAction {
                 .withUnretained(self)
                 .subscribe { owner, _ in
                     // TODO: - 저장 완료 후 검색 결과 리스트 업데이트 방식 논의 필요
-                    owner.showToast(message: "BookmarkSaved".localized, bottomViewHeight: 20.0)
+                    owner.showToast(message: "BookmarkSaved".localized)
                 }
                 .disposed(by: bag)
             
@@ -581,7 +581,7 @@ extension SearchVC: BookmarkCardAction {
             present(bottomSheetVC, animated: true)
         case 1:
             UIPasteboard.general.string = searchPlaceInfo.url
-            showToast(message: "LinkCopied".localized, bottomViewHeight: 20.0)
+            showToast(message: "LinkCopied".localized)
         default:
             break
         }
@@ -594,7 +594,7 @@ extension SearchVC: BookmarkCardAction {
             showBottomSheet(index: index)
         case 1:
             UIPasteboard.general.string = searchPlaceInfo.url
-            showToast(message: "LinkCopied".localized, bottomViewHeight: 20.0)
+            showToast(message: "LinkCopied".localized)
         case 2:
             print("TODO: - Delete Bookmark API to be call")
         default:

--- a/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
@@ -563,9 +563,9 @@ extension SearchVC: BookmarkCardAction {
     }
     
     private func actionDefaultPlaceInfoCell(index: Int, row: Int) {
+        let searchPlaceInfo = viewModel.output.searchResult.list.value[index]
         switch row {
         case 0:
-            let searchPlaceInfo = viewModel.output.searchResult.list.value[index]
             let bottomSheetVC = BookmarkBottomSheetVC(isBookmarking: false)
             bottomSheetVC.configureInitialData(with: searchPlaceInfo.toSearchPlaceListContent())
             
@@ -580,19 +580,21 @@ extension SearchVC: BookmarkCardAction {
             bottomSheetVC.modalPresentationStyle = .overFullScreen
             present(bottomSheetVC, animated: true)
         case 1:
-            // TODO: - 장소공유 기능
-            print("공유하기 메뉴 선택")
+            UIPasteboard.general.string = searchPlaceInfo.url
+            showToast(message: "LinkCopied".localized, bottomViewHeight: 20.0)
         default:
             break
         }
     }
     
     private func actionBookmarkCell(index: Int, row: Int) {
+        let searchPlaceInfo = viewModel.output.searchResult.list.value[index]
         switch row {
         case 0:
             showBottomSheet(index: index)
         case 1:
-            print("TODO: - Copy Link to be call")
+            UIPasteboard.general.string = searchPlaceInfo.url
+            showToast(message: "LinkCopied".localized, bottomViewHeight: 20.0)
         case 2:
             print("TODO: - Delete Bookmark API to be call")
         default:

--- a/Reet-Place/Reet-Place/Screen/MyPage/UserInfo/ViewController/DeleteAccountVC.swift
+++ b/Reet-Place/Reet-Place/Screen/MyPage/UserInfo/ViewController/DeleteAccountVC.swift
@@ -312,7 +312,7 @@ extension DeleteAccountVC {
                     accountDeletedVC.modalPresentationStyle = .overFullScreen
                     owner.present(accountDeletedVC, animated: false)
                 } else {
-                    owner.showToast(message: "UnlinkFailed".localized, bottomViewHeight: 20.0)
+                    owner.showToast(message: "UnlinkFailed".localized)
                 }
             })
             .disposed(by: bag)

--- a/Reet-Place/Reet-Place/Screen/Shared/View/PlaceInfoView.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/PlaceInfoView.swift
@@ -339,7 +339,9 @@ extension PlaceInfoView {
                       let owner = self.findViewController() else { return }
                 
                 let buttonFrameInSuperview = owner.view.convert(self.cardMenuButton.frame, from: self.placeNameStackView)
-                self.delegate?.showMenu(index: cellIndex, location: buttonFrameInSuperview, selectMenuType: self.groupIconImageView.image == nil ? .defaultPlaceInfo : .bookmarked)
+                self.delegate?.showMenu(index: cellIndex, 
+                                        location: buttonFrameInSuperview,
+                                        selectMenuType: self.groupIconImageView.image == nil ? .defaultPlaceInfo : .bookmarked)
             })
             .disposed(by: bag)
     }

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/SelectBoxStyle.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetSelectBox/SelectBoxStyle.swift
@@ -17,7 +17,7 @@ extension SelectBoxStyle {
     var selectTitle: [String] {
         switch self {
         case .defaultPlaceInfo:
-            return ["북마크", "공유하기"]
+            return ["북마크", "링크복사"]
         case .bookmarked:
             return ["북마크 수정", "링크복사", "북마크 삭제"]
         }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
- 더보기 버튼을 눌렀을 때 노출되는 공유하기 기능을 링크 복사로 통일하고,
링크 복사 가능을 구현했습니다~!

## 📋 변경 사항
### 1. Model 수정
- 더보기 버튼 -> 링크 복사 시 장소 상세 링크가 필요하기 때문에 각 모델들에 placeDetailURL이 추가되었습니다.

### 2. 클립 보드에 장소 상세 링크 복사 연결
- UIPasteboard를 이용해 간단하게 구현할 수 있습니다~!

### 3. Toast Message bottomViewHeight 기본값 지정
- Toast Message의 bottom이 safe area로 잡혀있고, padding 값도 지정되어 있기 때문에 bottomViewHeight의 기본값을 0으로 지정해뒀습니다.
- safe area와 Toast Message 사이에 추가로 뷰가 있고, 그 뷰만큼 Toast Message를 위로 올리고 싶다면 (ex. 바텀시트 후 북마크 완료 토스트) 해당 뷰의 높이를 showToast 메서드의 파라미터로 넘겨주시면 됩니다!

## 🔍 Code Review
혹시 수정된 모델 중 현재 작업에서 사용하고 계신 모델이 있는지 확인해주시면 좋을 것 같아요!

## 📸 ScreenShot
<img src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/51712973/1986ca3d-a629-4d83-995f-4cb6a7a4f974" width="300px" />
<img src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/51712973/f2ea3523-2631-4035-af95-aa0f83084d26" width="300px" />


### 연결된 이슈 Close
close #99 
