### PR TITLE
Feat/#116 카테고리 장소목록 조회방식 수정 및 하단목록 표시 구현

### DIFF
--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -135,6 +135,8 @@
 		3C4F12BA2B490D9F00184F16 /* Array+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4F12B92B490D9F00184F16 /* Array+.swift */; };
 		3C5C8BCF2B70D0770035BC0C /* CategoryFilterResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5C8BCE2B70D0770035BC0C /* CategoryFilterResponseModel.swift */; };
 		3C5C8BD12B7119AD0035BC0C /* PlaceCategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5C8BD02B7119AD0035BC0C /* PlaceCategoryModel.swift */; };
+		3C5C8BD32B71FBEB0035BC0C /* PlaceResultListCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5C8BD22B71FBEA0035BC0C /* PlaceResultListCVC.swift */; };
+		3C5C8BD52B7206780035BC0C /* PlaceResultListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5C8BD42B7206780035BC0C /* PlaceResultListDataSource.swift */; };
 		3C72D92C2B3401F200AF2190 /* ReetPlace.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 3C72D92A2B3401F200AF2190 /* ReetPlace.xcdatamodeld */; };
 		3C72D92E2B34043D00AF2190 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C72D92D2B34043D00AF2190 /* CoreDataManager.swift */; };
 		3C72D9302B34074800AF2190 /* CoreDataEntityList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C72D92F2B34074800AF2190 /* CoreDataEntityList.swift */; };
@@ -341,6 +343,8 @@
 		3C4F12B92B490D9F00184F16 /* Array+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+.swift"; sourceTree = "<group>"; };
 		3C5C8BCE2B70D0770035BC0C /* CategoryFilterResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryFilterResponseModel.swift; sourceTree = "<group>"; };
 		3C5C8BD02B7119AD0035BC0C /* PlaceCategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceCategoryModel.swift; sourceTree = "<group>"; };
+		3C5C8BD22B71FBEA0035BC0C /* PlaceResultListCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceResultListCVC.swift; sourceTree = "<group>"; };
+		3C5C8BD42B7206780035BC0C /* PlaceResultListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceResultListDataSource.swift; sourceTree = "<group>"; };
 		3C72D92B2B3401F200AF2190 /* ReetPlace.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = ReetPlace.xcdatamodel; sourceTree = "<group>"; };
 		3C72D92D2B34043D00AF2190 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		3C72D92F2B34074800AF2190 /* CoreDataEntityList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataEntityList.swift; sourceTree = "<group>"; };
@@ -834,6 +838,7 @@
 				3CFBC6FE2A64FF5C00540C7F /* DetailCategoryChipCVC.swift */,
 				3CFBC7002A65013000540C7F /* PlaceCategoryChipCVC.swift */,
 				3C8FB2712B3AC4780022B441 /* CategoryDetailListCVC.swift */,
+				3C5C8BD22B71FBEA0035BC0C /* PlaceResultListCVC.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -1242,6 +1247,7 @@
 				3C04A7C62A51ACB000A31FA3 /* SearchHistoryListDataSource.swift */,
 				3C8FB26F2B3AC0980022B441 /* CategoryDetailListDataSource.swift */,
 				3C0047642B3D5896009B547D /* CategoryDetailDataSource.swift */,
+				3C5C8BD42B7206780035BC0C /* PlaceResultListDataSource.swift */,
 			);
 			path = Datasource;
 			sourceTree = "<group>";
@@ -1382,6 +1388,7 @@
 				3C09F6942A5E599600B6B0BF /* APIToken.swift in Sources */,
 				3C3AC3002A36EE870023D3DE /* SearchVM.swift in Sources */,
 				3C09F69E2A5FBA5400B6B0BF /* DeleteAccountSurveyType.swift in Sources */,
+				3C5C8BD52B7206780035BC0C /* PlaceResultListDataSource.swift in Sources */,
 				3C4AE3422AFDFE4B001C8EC6 /* SearchPlaceKeywordRequestModel.swift in Sources */,
 				0EB8D81429FFFF9D00E79BA4 /* AccountDeletedVC.swift in Sources */,
 				3C423F2E29AAF734003B7B7D /* CategoryChipStyle.swift in Sources */,
@@ -1479,6 +1486,7 @@
 				A49515F129A0764400A12EE1 /* UserProfileView.swift in Sources */,
 				3C2AF0CD2990D6BC00E36342 /* ReetPlaceTBC.swift in Sources */,
 				3C2AED7A2990B3C300E36342 /* Loadable.swift in Sources */,
+				3C5C8BD32B71FBEB0035BC0C /* PlaceResultListCVC.swift in Sources */,
 				3CE3CC3D2ACFE0AA0027FB5E /* SearchPlaceKeywordResponseModel.swift in Sources */,
 				3C8FB2722B3AC4780022B441 /* CategoryDetailListCVC.swift in Sources */,
 				A4EFC09B299E6C9900B066AF /* LoginView.swift in Sources */,

--- a/Reet-Place/Reet-Place/Global/Datasource/PlaceResultListDataSource.swift
+++ b/Reet-Place/Reet-Place/Global/Datasource/PlaceResultListDataSource.swift
@@ -1,0 +1,21 @@
+//
+//  PlaceResultListDataSource.swift
+//  Reet-Place
+//
+//  Created by Kim HeeJae on 2023/12/19.
+//
+
+import RxDataSources
+
+struct PlaceResultListDataSource {
+    var items: [Item]
+}
+
+extension PlaceResultListDataSource: SectionModelType {
+    typealias Item = SearchPlaceListContent
+    
+    init(original: PlaceResultListDataSource, items: [Item]) {
+        self = original
+        self.items = items
+    }
+}

--- a/Reet-Place/Reet-Place/Global/Enum/BookmarkType.swift
+++ b/Reet-Place/Reet-Place/Global/Enum/BookmarkType.swift
@@ -13,7 +13,7 @@ enum BookmarkType: String {
     case want // 가보고 싶어요
     case gone // 다녀왔어요
     
-    init?(rawValue: String) {
+    init(rawValue: String) {
         switch rawValue {
         case "WANT":
             self = .want

--- a/Reet-Place/Reet-Place/Global/Enum/PlaceCategoryList.swift
+++ b/Reet-Place/Reet-Place/Global/Enum/PlaceCategoryList.swift
@@ -16,7 +16,7 @@ enum PlaceCategoryList: String {
     case cafe
     case culture
     
-    init?(rawValue: String) {
+    init(rawValue: String) {
         switch rawValue {
         case "REET_PLACE_POPULAR":
             self = .reetPlaceHot

--- a/Reet-Place/Reet-Place/Global/Enum/PlaceCategoryList.swift
+++ b/Reet-Place/Reet-Place/Global/Enum/PlaceCategoryList.swift
@@ -44,8 +44,8 @@ extension PlaceCategoryList: CaseIterable {}
 
 // MARK: - Custom String Convertible
 
-extension PlaceCategoryList: CustomStringConvertible {
-    var description: String {
+extension PlaceCategoryList {
+    var name: String {
         switch self {
         case .reetPlaceHot:
             return "👀 릿플 인기"

--- a/Reet-Place/Reet-Place/Global/Enum/TabPlaceCategoryList.swift
+++ b/Reet-Place/Reet-Place/Global/Enum/TabPlaceCategoryList.swift
@@ -20,7 +20,7 @@ enum TabPlaceCategoryList: String {
     case cafe = "카페"
     case culture = "문화생활"
     
-    init?(rawValue: String) {
+    init(rawValue: String) {
         switch rawValue {
         case "ALL":
             self = .all

--- a/Reet-Place/Reet-Place/Global/Extension/Array+.swift
+++ b/Reet-Place/Reet-Place/Global/Extension/Array+.swift
@@ -14,4 +14,9 @@ extension Array where Element: Comparable {
         return self.count == other.count && self.sorted() == other.sorted()
     }
     
+    /// safe로 전달받는 인덱스 값이 유효한 경우 해당되는 값 반환 / 아닌 경우 nil 반환
+    subscript (safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+    
 }

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkMapVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkMapVC.swift
@@ -21,13 +21,11 @@ final class BookmarkMapVC: BaseNavigationViewController {
     
     private let mapView: NMFMapView = .init()
     
-    
     // MARK: - Variables and Properties
     
     private let viewModel: BookmarkMapVM = .init()
     private let bookmarkType: BookmarkSearchType
     private var markers: [NMFMarker] = .init()
-    
     
     // MARK: - Initialize
     
@@ -39,7 +37,6 @@ final class BookmarkMapVC: BaseNavigationViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
     
     // MARK: - Life Cycle
     
@@ -71,7 +68,7 @@ final class BookmarkMapVC: BaseNavigationViewController {
     
     private func configureMarkers(from summaries: [BookmarkSummaryModel]) {
         summaries.forEach { summary in
-            guard let bookmarkType = BookmarkType(rawValue: summary.type) else { return }
+            let bookmarkType = BookmarkType(rawValue: summary.type)
             
             let marker = NMFMarker()
             marker.position = NMGLatLng(lat: summary.lat, lng: summary.lng)
@@ -115,7 +112,6 @@ final class BookmarkMapVC: BaseNavigationViewController {
     
 }
 
-
 // MARK: - Configure
 
 extension BookmarkMapVC {
@@ -136,7 +132,6 @@ extension BookmarkMapVC {
     }
     
 }
-
 
 // MARK: - Layout
 

--- a/Reet-Place/Reet-Place/Screen/Home/Cell/CategoryChipCVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Cell/CategoryChipCVC.swift
@@ -13,12 +13,6 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
-/// 카테고리 칩과 관련된 액션을 정의
-protocol CategoryChipCVCAction {
-    /// 선택된 카테고리 종류를 파라미터 값으로 전달 및 액션 구현
-    func tapCategoryChip(selectedCategory: PlaceCategoryList)
-}
-
 class CategoryChipCVC: BaseCollectionViewCell {
     
     // MARK: - UI components
@@ -52,8 +46,6 @@ class CategoryChipCVC: BaseCollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        
-        placeCategoryButton.title = .empty
     }
     
     // MARK: - Functions

--- a/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceCategoryChipCVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceCategoryChipCVC.swift
@@ -10,18 +10,13 @@ class PlaceCategoryChipCVC: CategoryChipCVC {
     // MARK: - Variables and Properties
     
     private var categoryType: PlaceCategoryList?
-    var delegate: CategoryChipCVCAction?
     
     // MARK: - Override
     
-    override func didTapPlaceCategoryButton() {
-        guard let categoryType = categoryType
-        else {
-            print("cannot find category place name")
-            return
+    override var isSelected: Bool {
+        didSet {
+            placeCategoryButton.isSelected = isSelected
         }
-        
-        delegate?.tapCategoryChip(selectedCategory: categoryType)
     }
     
 }
@@ -33,9 +28,10 @@ extension PlaceCategoryChipCVC {
     /// 홈 화면의 PlaceCategoryChipCVC 장소 정보 초기화
     func configurePlaceCategoryChipCVC(placeCategory: PlaceCategoryList) {
         categoryType = placeCategory
-        placeCategoryButton.configureButton(with: placeCategory.description, for: .primary)
         
-        placeCategoryButton.isSelected = placeCategory == .reetPlaceHot
+        placeCategoryButton.configureButton(with: placeCategory.description, for: .primary)
+        placeCategoryButton.isSelected = isSelected
+        placeCategoryButton.isUserInteractionEnabled = false
     }
     
 }

--- a/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceCategoryChipCVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceCategoryChipCVC.swift
@@ -29,7 +29,7 @@ extension PlaceCategoryChipCVC {
     func configurePlaceCategoryChipCVC(placeCategory: PlaceCategoryList) {
         categoryType = placeCategory
         
-        placeCategoryButton.configureButton(with: placeCategory.description, for: .primary)
+        placeCategoryButton.configureButton(with: placeCategory.name, for: .primary)
         placeCategoryButton.isSelected = isSelected
         placeCategoryButton.isUserInteractionEnabled = false
     }

--- a/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceResultListCVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceResultListCVC.swift
@@ -72,12 +72,16 @@ extension PlaceResultListCVC {
             thumbnailImageView.setImage(with: thumbnailImage, placeholder: AssetsImages.placeResultThumbnail)
         }
         
+        var simpleAddress: String = .empty
         let addressList = placeResultInfo.lotNumberAddress.split(separator: " ")
-        let city = addressList[1]
-        let dong = addressList[2]
+        if let city = addressList[safe: 11],
+           let dong = addressList[safe: 21] {
+            simpleAddress = city + " " + dong
+        }
+        
         placeInformationView.configurePlaceInfomation(
             placeName: placeResultInfo.name,
-            address: city + " " + dong,
+            address: simpleAddress,
             category: PlaceCategoryList(rawValue: placeResultInfo.category).name
         )
     }

--- a/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceResultListCVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceResultListCVC.swift
@@ -1,0 +1,112 @@
+//
+//  PlaceResultListCVC.swift
+//  Reet-Place
+//
+//  Created by Kim HeeJae on 2023/12/19.
+//
+
+import UIKit
+
+import Then
+import SnapKit
+
+import RxSwift
+import RxCocoa
+
+class PlaceResultListCVC: BaseCollectionViewCell {
+    
+    // MARK: - UI components
+    
+    private let baseStackView = UIStackView()
+        .then {
+            $0.axis = .horizontal
+            $0.distribution = .fill
+            $0.alignment = .center
+            $0.spacing = 12.0
+        }
+    private let thumbnailImageView = UIImageView()
+        .then {
+            $0.image = AssetsImages.placeResultThumbnail
+            
+            $0.contentMode = .scaleAspectFill
+            $0.layer.borderColor = AssetColors.gray300.cgColor
+            $0.layer.cornerRadius = 4.0
+            $0.layer.masksToBounds = true
+        }
+    private let placeInformationView = PlaceInformationView(placeNameFont: .subtitle1)
+    
+    // MARK: - Variables and Properties
+    
+    private var bag = DisposeBag()
+    
+    // MARK: - Life Cycle
+    
+    override func configureView() {
+        super.configureView()
+        
+        configureContentView()
+    }
+    
+    override func layoutView() {
+        super.layoutView()
+        
+        configureLayout()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        thumbnailImageView.image = AssetsImages.placeResultThumbnail
+    }
+    
+    // MARK: - Functions
+}
+
+// MARK: - Configure
+
+extension PlaceResultListCVC {
+    
+    /// 카테고리 장소검색 결과 목록 PlaceResultListCVC 정보 초기화
+    func configurePlaceResultListCVC(placeResultInfo: SearchPlaceListContent) {
+        if let thumbnailImage = placeResultInfo.thumbnailImage {
+            thumbnailImageView.setImage(with: thumbnailImage, placeholder: AssetsImages.placeResultThumbnail)
+        }
+        
+        let addressList = placeResultInfo.lotNumberAddress.split(separator: " ")
+        let city = addressList[1]
+        let dong = addressList[2]
+        placeInformationView.configurePlaceInfomation(
+            placeName: placeResultInfo.name,
+            address: city + " " + dong,
+            category: PlaceCategoryList(rawValue: placeResultInfo.category)!.name
+        )
+    }
+    
+    private func configureContentView() {
+        contentView.backgroundColor = .white
+        contentView.layer.cornerRadius = 8.0
+        contentView.layer.masksToBounds = true
+    }
+    
+}
+
+// MARK: - Layout
+
+extension PlaceResultListCVC {
+    
+    private func configureLayout() {
+        contentView.addSubviews([baseStackView])
+        [thumbnailImageView,
+         placeInformationView].forEach {
+            baseStackView.addArrangedSubview($0)
+        }
+        
+        baseStackView.snp.makeConstraints {
+            $0.edges.equalTo(contentView).inset(12.0)
+        }
+        thumbnailImageView.snp.makeConstraints {
+            $0.width.height.equalTo(56.0)
+        }
+    }
+    
+}

--- a/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceResultListCVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceResultListCVC.swift
@@ -78,7 +78,7 @@ extension PlaceResultListCVC {
         placeInformationView.configurePlaceInfomation(
             placeName: placeResultInfo.name,
             address: city + " " + dong,
-            category: PlaceCategoryList(rawValue: placeResultInfo.category)!.name
+            category: PlaceCategoryList(rawValue: placeResultInfo.category).name
         )
     }
     

--- a/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceResultListCVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceResultListCVC.swift
@@ -21,7 +21,7 @@ class PlaceResultListCVC: BaseCollectionViewCell {
         .then {
             $0.axis = .horizontal
             $0.distribution = .fill
-            $0.alignment = .center
+            $0.alignment = .top
             $0.spacing = 12.0
         }
     private let thumbnailImageView = UIImageView()
@@ -85,7 +85,7 @@ extension PlaceResultListCVC {
     private func configureContentView() {
         contentView.backgroundColor = .white
         contentView.layer.cornerRadius = 8.0
-        contentView.layer.masksToBounds = true
+        contentView.addShadow()
     }
     
 }
@@ -103,6 +103,9 @@ extension PlaceResultListCVC {
         
         baseStackView.snp.makeConstraints {
             $0.edges.equalTo(contentView).inset(12.0)
+        }
+        placeInformationView.snp.updateConstraints {
+            $0.height.equalTo(46.0)
         }
         thumbnailImageView.snp.makeConstraints {
             $0.width.height.equalTo(56.0)

--- a/Reet-Place/Reet-Place/Screen/Home/Model/SearchPlaceListRequestModel.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Model/SearchPlaceListRequestModel.swift
@@ -12,7 +12,7 @@ import Alamofire
 
 struct SearchPlaceListRequestModel: Codable {
     let lat, lng, category: String
-    let subCategory: [String]
+    var subCategory: [String]
 }
 
 // MARK: - Paramters

--- a/Reet-Place/Reet-Place/Screen/Home/Model/SearchPlaceListResponseModel.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Model/SearchPlaceListResponseModel.swift
@@ -18,6 +18,7 @@ struct SearchPlaceListResponseModel: Codable {
 struct SearchPlaceListContent: Codable {
     let kakaoPID, name: String
     let url: String
+    let thumbnailImage: String?
     let kakaoCategoryName, category, subCategory: String
     let categoryGroupCode: String?
     let phone, lotNumberAddress, roadAddress, lat, lng: String
@@ -26,7 +27,7 @@ struct SearchPlaceListContent: Codable {
 
     enum CodingKeys: String, CodingKey {
         case kakaoPID = "kakaoPid"
-        case name, url, categoryGroupCode, kakaoCategoryName, category, subCategory, phone, lotNumberAddress, roadAddress, lat, lng, type
+        case name, url, thumbnailImage, categoryGroupCode, kakaoCategoryName, category, subCategory, phone, lotNumberAddress, roadAddress, lat, lng, type
         case bookmarkID = "bookmarkId"
     }
 }

--- a/Reet-Place/Reet-Place/Screen/Home/Search/Cell/SearchResultTVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/Cell/SearchResultTVC.swift
@@ -129,7 +129,7 @@ extension SearchResultTVC {
         
         // 2. 징소정보
         placeNameLabel.text = placeInformation.name
-        categoryLabel.text = PlaceCategoryList(rawValue: placeInformation.category)?.name
+        categoryLabel.text = PlaceCategoryList(rawValue: placeInformation.category).name
         addressLabel.text = placeInformation.roadAddress
     }
     

--- a/Reet-Place/Reet-Place/Screen/Home/Search/Cell/SearchResultTVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/Cell/SearchResultTVC.swift
@@ -129,7 +129,7 @@ extension SearchResultTVC {
         
         // 2. 징소정보
         placeNameLabel.text = placeInformation.name
-        categoryLabel.text = PlaceCategoryList(rawValue: placeInformation.category)?.description
+        categoryLabel.text = PlaceCategoryList(rawValue: placeInformation.category)?.name
         addressLabel.text = placeInformation.roadAddress
     }
     

--- a/Reet-Place/Reet-Place/Screen/Home/Search/Model/SearchPlaceKeywordResponseModel.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/Model/SearchPlaceKeywordResponseModel.swift
@@ -39,6 +39,7 @@ extension SearchPlaceKeywordListContent {
             kakaoPID: kakaoPID,
             name: name,
             url: url,
+            thumbnailImage: thumbnailImage,
             kakaoCategoryName: kakaoCategoryName,
             category: category,
             subCategory: subCategory,

--- a/Reet-Place/Reet-Place/Screen/Home/ViewController/CategoryFilterBottomSheet.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewController/CategoryFilterBottomSheet.swift
@@ -171,14 +171,14 @@ extension CategoryFilterBottomSheet {
     
     private func bindInputMenuTabBarView() {
         menuTabBarView.menuBarCollectionView.rx.itemSelected
-            .asDriver()
-            .drive(onNext: { [weak self] indexPath in
-                guard let self = self else { return }
+            .withUnretained(self)
+            .bind(onNext: { owner, indexPath in
+                owner.menuTabBarView.menuBarCollectionView.selectItem(at: indexPath, 
+                                                                      animated: true,
+                                                                      scrollPosition: .centeredHorizontally)
                 
-                self.menuTabBarView.menuBarCollectionView.selectItem(at: indexPath, animated: true, scrollPosition: .centeredHorizontally)
-                
-                let offset = CGFloat(indexPath.row) * self.screenWidth
-                self.categoryDetailListCollectionView.scrollToHorizontalOffset(offset: offset)
+                let offset = CGFloat(indexPath.row) * owner.screenWidth
+                owner.categoryDetailListCollectionView.scrollToHorizontalOffset(offset: offset)
             })
             .disposed(by: bag)
     }
@@ -191,7 +191,9 @@ extension CategoryFilterBottomSheet {
                 
                 let menuIndex = Int(targetContentOffset.pointee.x / self.categoryDetailListCollectionView.frame.width)
                 let indexPath = IndexPath(item: menuIndex, section: 0)
-                self.menuTabBarView.menuBarCollectionView.selectItem(at: indexPath, animated: true, scrollPosition: .centeredHorizontally)
+                self.menuTabBarView.menuBarCollectionView.selectItem(at: indexPath, 
+                                                                     animated: true,
+                                                                     scrollPosition: .centeredHorizontally)
             })
             .disposed(by: bag)
     }

--- a/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
@@ -231,13 +231,6 @@ extension HomeVC {
 extension HomeVC {
     
     private func bindCollectionView() {
-        placeCategoryCollectionView.rx.modelSelected(PlaceCategoryList.self)
-            .withUnretained(self)
-            .bind(onNext: { owner, category in
-                print(category)
-            })
-            .disposed(by: bag)
-        
         placeCategoryCollectionView.rx.itemSelected
             .withUnretained(self)
             .bind(onNext: { owner, indexPath in

--- a/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
@@ -190,7 +190,7 @@ extension HomeVC {
                 let marker = NMFMarker()
                 marker.position = NMGLatLng(lat: Double(placeInfo.lat)!, lng: Double(placeInfo.lng)!)
                 
-                let bookmarkType = BookmarkType(rawValue: placeInfo.type ?? .empty)!
+                let bookmarkType = BookmarkType(rawValue: placeInfo.type ?? .empty)
                 marker.iconImage = NMFOverlayImage(image: MarkerType.round(bookmarkType.markerState).image)
                 marker.touchHandler = { (overlay: NMFOverlay) -> Bool in
                     self.presentPlaceBottomSheet(placeInfo: placeInfo)

--- a/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
@@ -186,9 +186,14 @@ extension HomeVC {
         DispatchQueue.global(qos: .default).async { [weak self] in
             guard let self = self else { return }
             
-            searchPlaceList.contents.forEach { placeInfo in
+            searchPlaceList.contents.forEach { [weak self] placeInfo in
+                guard let self = self else { return }
+                
                 let marker = NMFMarker()
-                marker.position = NMGLatLng(lat: Double(placeInfo.lat)!, lng: Double(placeInfo.lng)!)
+                if let latitude = Double(placeInfo.lat),
+                   let longitude = Double(placeInfo.lng) {
+                    marker.position = NMGLatLng(lat: latitude, lng: longitude)
+                }
                 
                 let bookmarkType = BookmarkType(rawValue: placeInfo.type ?? .empty)
                 marker.iconImage = NMFOverlayImage(image: MarkerType.round(bookmarkType.markerState).image)

--- a/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
@@ -70,6 +70,29 @@ class HomeVC: BaseViewController {
             $0.register(PlaceCategoryChipCVC.self, forCellWithReuseIdentifier: PlaceCategoryChipCVC.className)
         }
     
+    private let placeResultListCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+        .then {
+            $0.isHidden = true
+            
+            $0.backgroundColor = .clear
+            
+            let layout = UICollectionViewFlowLayout()
+                .then {
+                    $0.scrollDirection = .horizontal
+                    $0.minimumLineSpacing = 8.0
+                    $0.minimumInteritemSpacing = 4.0
+                    $0.sectionInset = UIEdgeInsets(top: 0.0, left: constants.SectionInset.padding, bottom: 0.0, right: constants.SectionInset.padding)
+                    $0.estimatedItemSize = CGSize(width: constants.width, height: constants.height)
+                    $0.itemSize = UICollectionViewFlowLayout.automaticSize
+                }
+            $0.collectionViewLayout = layout
+            
+            $0.showsHorizontalScrollIndicator = false
+            $0.clipsToBounds = true
+            
+            $0.register(PlaceResultListCVC.self, forCellWithReuseIdentifier: PlaceResultListCVC.className)
+        }
+    
     private let currentPositionButton = ReetFAB(size: .round(.small), title: nil, image: .directionTool)
     
     // MARK: - Variables and Properties
@@ -77,7 +100,20 @@ class HomeVC: BaseViewController {
     private let viewModel = HomeVM()
     
     private let locationManager = CLLocationManager()
-    private var markerList: [NMFMarker] = []
+    private var markerList: [String:NMFMarker] = [:]
+    
+    private enum Constants {
+        enum PlaceResultListCollectionView {
+            static let width: CGFloat = 240.0
+            static let height: CGFloat = 80.0
+            static let padding: CGFloat = 12.0
+            
+            enum SectionInset {
+                static let padding: CGFloat = 20.0
+            }
+        }
+    }
+    private typealias constants = Constants.PlaceResultListCollectionView
     
     // MARK: - Life Cycle
     
@@ -106,10 +142,24 @@ class HomeVC: BaseViewController {
         super.bindOutput()
         
         bindPlaceCategoryList()
-        bindSearchPlacesResult()
+        bindSearchPlaceListResult()
     }
     
     // MARK: - Functions
+    
+    private func presentPlaceBottomSheet(placeInfo: SearchPlaceListContent) {
+        let marker = markerList[placeInfo.kakaoPID]
+        
+        if let location = marker?.position {
+            mapView.moveCamera(NMFCameraUpdate(scrollTo: NMGLatLng(lat: location.lat, lng: location.lng)))
+        }
+        
+        let bottomSheetVC = PlaceBottomSheet()
+        bottomSheetVC.configurePlaceBottomSheet(placeInfo: placeInfo,
+                                                marker: marker)
+        present(bottomSheetVC, animated: false)
+    }
+    
 }
 
 // MARK: - Configure
@@ -124,16 +174,18 @@ extension HomeVC {
         locationManager.delegate = self
     }
     
-    private func configureSearchPlacesResult(searchPlaceList: SearchPlaceListResponseModel) {
+    private func configureMapViewMarker(searchPlaceList: SearchPlaceListResponseModel) {
         // 기존 마커 표시 초기화
         markerList.forEach {
-            $0.mapView = nil
+            $0.value.mapView = nil
         }
-        markerList = []
+        markerList = [:]
         
         // 조회한 카테고리 목록들에 대한 마커 생성
         // 백그라운드 스레드
-        DispatchQueue.global(qos: .default).async {
+        DispatchQueue.global(qos: .default).async { [weak self] in
+            guard let self = self else { return }
+            
             searchPlaceList.contents.forEach { placeInfo in
                 let marker = NMFMarker()
                 marker.position = NMGLatLng(lat: Double(placeInfo.lat)!, lng: Double(placeInfo.lng)!)
@@ -141,28 +193,19 @@ extension HomeVC {
                 let bookmarkType = BookmarkType(rawValue: placeInfo.type ?? .empty)!
                 marker.iconImage = NMFOverlayImage(image: MarkerType.round(bookmarkType.markerState).image)
                 marker.touchHandler = { (overlay: NMFOverlay) -> Bool in
-                    let bottomSheetVC = PlaceBottomSheet()
-                    bottomSheetVC.modalPresentationStyle = .custom
-                    bottomSheetVC.modalPresentationStyle = .overFullScreen
-                    
-                    bottomSheetVC.configurePlaceBottomSheet(searchPlaceInfo: placeInfo,
-                                                            bookmarkType: bookmarkType,
-                                                            marker: marker)
-                    
-                    self.present(bottomSheetVC, animated: false)
-                    
+                    self.presentPlaceBottomSheet(placeInfo: placeInfo)
                     return true
                 }
                 
-                self.markerList.append(marker)
+                self.markerList[placeInfo.kakaoPID] = marker
             }
-
+            
             // 메인 스레드
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 
                 for marker in markerList {
-                    marker.mapView = self.mapView
+                    marker.value.mapView = self.mapView
                 }
             }
             
@@ -180,6 +223,7 @@ extension HomeVC {
         view.addSubviews([mapView,
                           searchTextField, cancelButton, searchButton,
                           categoryFilterButton, placeCategoryCollectionView,
+                          placeResultListCollectionView,
                           currentPositionButton])
         
         // Make Constraints
@@ -219,8 +263,15 @@ extension HomeVC {
             $0.trailing.equalTo(mapView)
         }
         
+        placeResultListCollectionView.snp.makeConstraints {
+            $0.height.equalTo(constants.height)
+            
+            $0.leading.trailing.equalTo(mapView)
+            $0.bottom.equalTo(mapView.snp.bottom).offset(-constants.padding)
+        }
+        
         currentPositionButton.snp.makeConstraints {
-            $0.trailing.bottom.equalTo(mapView).offset(-20.0)
+            $0.trailing.bottom.equalTo(mapView).offset(-constants.SectionInset.padding)
         }
     }
     
@@ -231,15 +282,41 @@ extension HomeVC {
 extension HomeVC {
     
     private func bindCollectionView() {
-        placeCategoryCollectionView.rx.itemSelected
+        placeCategoryCollectionView.rx.modelSelected(PlaceCategoryList.self)
             .withUnretained(self)
-            .bind(onNext: { owner, indexPath in
-                let selectedCategory = PlaceCategoryList.allCases[indexPath.row]
+            .bind(onNext: { owner, selectedCategory in
+                owner.placeResultListCollectionView.scrollToTop()
                 
                 let latitude = owner.mapView.latitude.description
                 let longitude = owner.mapView.longitude.description
-                
-                owner.viewModel.requestSearchPlaces(category: selectedCategory, latitude: latitude, longitude: longitude)
+                owner.viewModel.requestSearchPlaces(category: selectedCategory, 
+                                                    latitude: latitude,
+                                                    longitude: longitude)
+            })
+            .disposed(by: bag)
+        
+        placeCategoryCollectionView.rx.itemSelected
+            .withUnretained(self)
+            .bind(onNext: { owner, indexPath in
+                owner.placeCategoryCollectionView.scrollToItem(at: indexPath, 
+                                                               at: .centeredHorizontally,
+                                                               animated: true)
+            })
+            .disposed(by: bag)
+        
+        placeResultListCollectionView.rx.modelSelected(SearchPlaceListContent.self)
+            .withUnretained(self)
+            .bind(onNext: { owner, placeInfo in
+                owner.presentPlaceBottomSheet(placeInfo: placeInfo)
+            })
+            .disposed(by: bag)
+        
+        placeResultListCollectionView.rx.itemSelected
+            .withUnretained(self)
+            .bind(onNext: { owner, indexPath in
+                owner.placeResultListCollectionView.scrollToItem(at: indexPath, 
+                                                                 at: .centeredHorizontally,
+                                                                 animated: true)
             })
             .disposed(by: bag)
     }
@@ -333,12 +410,47 @@ extension HomeVC {
             .disposed(by: bag)
     }
     
-    private func bindSearchPlacesResult() {
+    private func bindSearchPlaceListResult() {
+        let dataSource = RxCollectionViewSectionedReloadDataSource<PlaceResultListDataSource> { _,
+            collectionView,
+            indexPath,
+            placeResult in
+            
+            guard let cell = collectionView
+                .dequeueReusableCell(withReuseIdentifier: PlaceResultListCVC.className,
+                                     for: indexPath) as? PlaceResultListCVC else {
+                fatalError("Cannot deqeue cells named PlaceResultListCVC")
+            }
+            cell.configurePlaceResultListCVC(placeResultInfo: placeResult)
+            
+            return cell
+        }
+        
+        viewModel.output.placeResultListDataSource
+            .bind(to: placeResultListCollectionView.rx.items(dataSource: dataSource))
+            .disposed(by: bag)
+        
         viewModel.output.searchPlaceList
-            .subscribe(onNext: { [weak self] data in
-                guard let self = self else { return }
+            .withUnretained(self)
+            .subscribe(onNext: { owner, data in
+                owner.configureMapViewMarker(searchPlaceList: data)
                 
-                self.configureSearchPlacesResult(searchPlaceList: data)
+                if owner.placeResultListCollectionView.isHidden {
+                    owner.placeResultListCollectionView.isHidden = false
+                }
+                
+                var updateConstant: CGFloat = 0.0
+                switch data.contents.count > 1 {
+                case true:
+                    updateConstant = constants.padding + constants.height + 16.0
+                case false:
+                    updateConstant = constants.SectionInset.padding
+                }
+                owner.currentPositionButton.snp.updateConstraints {
+                    $0.bottom.equalTo(owner.mapView).offset(-updateConstant)
+                }
+                
+                owner.placeResultListCollectionView.reloadData()
             })
             .disposed(by: bag)
     }

--- a/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
@@ -88,7 +88,7 @@ final class HomeVC: BaseViewController {
             $0.collectionViewLayout = layout
             
             $0.showsHorizontalScrollIndicator = false
-            $0.clipsToBounds = true
+            $0.clipsToBounds = false
             
             $0.register(PlaceResultListCVC.self, forCellWithReuseIdentifier: PlaceResultListCVC.className)
         }

--- a/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
@@ -63,6 +63,7 @@ class HomeVC: BaseViewController {
                 }
             $0.collectionViewLayout = layout
             
+            $0.allowsMultipleSelection = false
             $0.showsHorizontalScrollIndicator = false
             $0.clipsToBounds = true
             
@@ -240,7 +241,12 @@ extension HomeVC {
         placeCategoryCollectionView.rx.itemSelected
             .withUnretained(self)
             .bind(onNext: { owner, indexPath in
-                // TODO: - 카테고리 버튼 연결
+                let selectedCategory = PlaceCategoryList.allCases[indexPath.row]
+                
+                let latitude = owner.mapView.latitude.description
+                let longitude = owner.mapView.longitude.description
+                
+                owner.viewModel.requestSearchPlaces(category: selectedCategory, latitude: latitude, longitude: longitude)
             })
             .disposed(by: bag)
     }
@@ -325,7 +331,6 @@ extension HomeVC {
                 fatalError("Cannot deqeue cells named PlaceCategoryChipCVC")
             }
             cell.configurePlaceCategoryChipCVC(placeCategory: categoryType)
-            cell.delegate = self
             
             return cell
         }
@@ -378,19 +383,6 @@ extension HomeVC: CLLocationManagerDelegate {
     
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         print("get location failed", error)
-    }
-    
-}
-
-// MARK: - CategoryChipCVC Action Delegate
-
-extension HomeVC: CategoryChipCVCAction {
-    
-    func tapCategoryChip(selectedCategory: PlaceCategoryList) {
-        let latitude = mapView.latitude.description
-        let longitude = mapView.longitude.description
-        
-        viewModel.requestSearchPlaces(targetSearchPlace: SearchPlaceListRequestModel(lat: latitude, lng: longitude, category: selectedCategory.parameterPlace, subCategory: selectedCategory.parameterSubCategoryList))
     }
     
 }

--- a/Reet-Place/Reet-Place/Screen/Home/ViewModel/HomeVM.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewModel/HomeVM.swift
@@ -77,7 +77,7 @@ extension HomeVM {
         // 비로그인 사용자의 경우
         if KeychainManager.shared.read(for: .accessToken) == nil,
            category != .reetPlaceHot {
-            searchPlaceListRequestModel.subCategory = CoreDataManager.shared.fetchSubCategoryList(targetTabPlace: TabPlaceCategoryList(rawValue: category.parameterPlace)!)
+            searchPlaceListRequestModel.subCategory = CoreDataManager.shared.fetchSubCategoryList(targetTabPlace: TabPlaceCategoryList(rawValue: category.parameterPlace))
         }
         
         apiSession.requestPost(urlResource: resource, parameter: searchPlaceListRequestModel.parameter)

--- a/Reet-Place/Reet-Place/Screen/Home/ViewModel/HomeVM.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewModel/HomeVM.swift
@@ -32,6 +32,9 @@ final class HomeVM: BaseViewModel {
         }
         
         var searchPlaceList = PublishRelay<SearchPlaceListResponseModel>()
+        var placeResultListDataSource: Observable<Array<PlaceResultListDataSource>> {
+            searchPlaceList.map { [PlaceResultListDataSource(items: $0.contents)] }
+        }
     }
     
     // MARK: - Life Cycle

--- a/Reet-Place/Reet-Place/Screen/Home/ViewModel/HomeVM.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewModel/HomeVM.swift
@@ -62,11 +62,22 @@ extension HomeVM: Output {
 
 extension HomeVM {
     
-    func requestSearchPlaces(targetSearchPlace: SearchPlaceListRequestModel) {
+    func requestSearchPlaces(category: PlaceCategoryList, latitude: String, longitude: String) {
         let path = "/api/places"
         let resource = URLResource<SearchPlaceListResponseModel>(path: path)
         
-        apiSession.requestPost(urlResource: resource, parameter: targetSearchPlace.parameter)
+        var searchPlaceListRequestModel = SearchPlaceListRequestModel(lat: latitude, 
+                                                                      lng: longitude,
+                                                                      category: category.parameterPlace,
+                                                                      subCategory: [])
+        
+        // 비로그인 사용자의 경우
+        if KeychainManager.shared.read(for: .accessToken) == nil,
+           category != .reetPlaceHot {
+            searchPlaceListRequestModel.subCategory = CoreDataManager.shared.fetchSubCategoryList(targetTabPlace: TabPlaceCategoryList(rawValue: category.parameterPlace)!)
+        }
+        
+        apiSession.requestPost(urlResource: resource, parameter: searchPlaceListRequestModel.parameter)
             .withUnretained(self)
             .subscribe(onNext: { owner, result in
                 switch result {

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetBottomSheet/PlaceBottomSheet.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetBottomSheet/PlaceBottomSheet.swift
@@ -106,7 +106,7 @@ final class PlaceBottomSheet: BaseViewController {
     init() {
         super.init(nibName: nil, bundle: nil)
         
-        modalPresentationStyle = .overFullScreen
+        modalPresentationStyle = .overCurrentContext
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -276,7 +276,9 @@ extension PlaceBottomSheet {
         view.layer.shadowOpacity = 0.4
         view.layer.shadowRadius = 16.0
         view.layer.shadowOffset = CGSize(width: 0, height: -2.0)
-        view.layer.masksToBounds = false
+        
+        view.layer.masksToBounds = true
+        view.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
     }
     
 }

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetBottomSheet/PlaceBottomSheet.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetBottomSheet/PlaceBottomSheet.swift
@@ -209,10 +209,10 @@ extension PlaceBottomSheet {
     func configurePlaceBottomSheet(placeInfo: SearchPlaceListContent, marker: NMFMarker?) {
         self.searchPlaceInfo = placeInfo
         self.placeName = placeInfo.name
-        self.bookmarkType = BookmarkType(rawValue: placeInfo.type ?? .empty)!
+        self.bookmarkType = BookmarkType(rawValue: placeInfo.type ?? .empty)
         self.marker = marker
         
-        let category = PlaceCategoryList(rawValue: placeInfo.category)!.name
+        let category = PlaceCategoryList(rawValue: placeInfo.category).name
         if let thumbnailImage = placeInfo.thumbnailImage {
             thumbnailImageView.setImage(with: thumbnailImage, placeholder: AssetsImages.placeResultThumbnail)
         }
@@ -240,7 +240,7 @@ extension PlaceBottomSheet {
         self.placeName = bookmarkSummary.name
         self.bookmarkType = bookmarkType
         self.marker = marker
-        let category = PlaceCategoryList(rawValue: bookmarkSummary.category)!.name
+        let category = PlaceCategoryList(rawValue: bookmarkSummary.category).name
         
         placeInformationView.configurePlaceInfomation(
             placeName: bookmarkSummary.name,

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetBottomSheet/PlaceInformationView.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetBottomSheet/PlaceInformationView.swift
@@ -15,13 +15,21 @@ class PlaceInformationView: BaseView {
     
     // MARK: - UI components
     
-    private let placeNameLabel = BaseAttributedLabel(font: .h4,
+    private let baseStackView = UIStackView()
+        .then {
+            $0.axis = .vertical
+            $0.distribution = .fill
+            $0.alignment = .leading
+            $0.spacing = 8.0
+        }
+    
+    private var placeNameLabel = BaseAttributedLabel(font: .h4,
                                         text: "PlaceName",
                                         alignment: .left,
                                         color: AssetColors.black)
     
     /// address, border, category 들어가는 stackView
-    let addressStackView = UIStackView()
+    private let addressStackView = UIStackView()
         .then {
             $0.spacing = 8.0
             $0.distribution = .fill
@@ -44,6 +52,22 @@ class PlaceInformationView: BaseView {
     // MARK: - Variables and Properties
     
     // MARK: - Life Cycle
+    
+    init(frame: CGRect = .zero,
+         placeNameFont: AssetFonts = .h4,
+         addressFont: AssetFonts = .caption,
+         categoryFont: AssetFonts = .caption) {
+        placeNameLabel = BaseAttributedLabel(font: placeNameFont,
+                                             text: "PlaceName",
+                                             alignment: .left,
+                                             color: AssetColors.black)
+        
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func configureView() {
         super.configureView()
@@ -81,29 +105,33 @@ extension PlaceInformationView {
 extension PlaceInformationView {
     
     private func configureLayout() {
-        addSubviews([placeNameLabel,
-                    addressStackView])
+        // Add Subviews
+        addSubviews([baseStackView])
+        
+        [placeNameLabel,
+         addressStackView].forEach {
+            baseStackView.addArrangedSubview($0)
+        }
+
         [addressLabel, addressBorder, categoryLabel].forEach {
             addressStackView.addArrangedSubview($0)
         }
         
-        
-        self.snp.makeConstraints {
-            $0.height.equalTo(50)
+        // Make Constraints
+        snp.makeConstraints {
+            $0.height.equalTo(50.0)
         }
         
-        placeNameLabel.snp.makeConstraints {
-            $0.top.equalTo(self)
-            $0.leading.equalTo(self)
+        baseStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
         
         addressStackView.snp.makeConstraints {
-            $0.leading.equalTo(self)
-            $0.bottom.equalTo(self)
+            $0.height.equalTo(14.0)
         }
         addressBorder.snp.makeConstraints {
-            $0.height.equalTo(8.0)
             $0.width.equalTo(1.0)
+            $0.height.equalTo(8.0)
         }
     }
     

--- a/Reet-Place/Reet-Place/Screen/Shared/View/ReetBottomSheet/PlaceInformationView.swift
+++ b/Reet-Place/Reet-Place/Screen/Shared/View/ReetBottomSheet/PlaceInformationView.swift
@@ -125,10 +125,6 @@ extension PlaceInformationView {
         baseStackView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-        
-        addressStackView.snp.makeConstraints {
-            $0.height.equalTo(14.0)
-        }
         addressBorder.snp.makeConstraints {
             $0.width.equalTo(1.0)
             $0.height.equalTo(8.0)


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
### 홈화면 상의 카테고리 메뉴버튼을 통해 카테고리별 조회 기능 방법을 수정
- 기존 연관된 카테고리 항목 → 사용자가 설정한 카테고리 하위 세부 카테고리 목록 설정에 따른 조회 방식으로 로직 수정
- 로그인/비로그인 사용자를 구별하여 세부 카테고리 파라미터를 서버에게 전달

> 로그인 사용자 : 상위 카테고리 항목만 파라미터로 전달(subCategory: [])
> 비로그인 사용자 : 카테고리 하위 세부 카테고리 목록을 **CoreData** 에서 조회 후 'subCategory' 항목에 담아 전달

### 카테고리 장소검색결과 목록 하단표시 기능추가
<img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/26570294/03e0e972-87c7-4ee1-845e-4231e8baa7bd">

- 디자인 상 누락되어 있던 장소검색 결과 목록 마커 표시 이외에 하단에 콜렉션뷰 형식으로 목록표시 기능 추가
- 하단 카테고리 목록 중 하나의 장소를 선택할 경우 기존 마커클릭시 팝업되던 PlaceBottomSheet를 팝업
- PlaceBottomSheet로 팝업되었던 장소표기 중 장소 썸네일 이미지 표시 추가

### 디자인 수정 요청사항 반영
- 카테고리 목록 중 하나를 클릭 할 경우 선택되었다는 표시 기능 반영(하나만 선택 가능)
<img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/26570294/03779bed-22ec-4459-ade7-e90b4d6c4f6c">

## 📋 변경 사항
### PlaceInformationView 리팩토링
**북마크 바텀시트**와 **장소 바텀시트** 등에 사용되는 `PlaceInformationView`에 대해 리팩토링을 진행하였습니다
> - 내부 레이아웃 구조 수정
> - 장소이름 폰트를 변경 할 수 있게 수정
> - 링크 버튼 액션 RxSwift 코드 수정

(확인은 한번 하였으나) 추후 북마크 바텀시트 관련 문제가 생기는 경우 공유해주시면 확인해보도록 하겠습니다!

### PlaceBottomSheet
PlaceBottomSheet를 사용 할 경우 기본적인 `modalPresentationStyle` 을 `overFullScreen`으로 사용 할 수 있게 코드를 추가하였습니다

## 🔍 Code Review
Xcode 콘솔 창 상에 경고문구를 표시하지 않고 코딩하려 했으나 PlaceBottomSheet가 팝업 된 이후 웹뷰가 푸시되늰 경우 아래와 같은 문구(**Unknown client**)가 발생하는데 원인을 찾지 못했습니다 🥲 ViewController를 관리하는 상위 직계가 누구냐와 관련된 문제인거 같기도 한데.. 혹시 아시는 부분이 있는 경우 피드백 부탁드립니다! (우선적으로 해당 경고창에 대한 공유를 드리고자 합니다)
<img width="300" alt="스크린샷 2024-02-07 오후 2 16 39" src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/26570294/c9aaa19c-18b5-4202-8dec-ff48f68f249d">

## 📸 ScreenShot (디자인 수정 반영 업데이트)
<img src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/26570294/b0421aeb-814f-4e3f-8f14-4327ed73ae07" width="300px" />

### 연결된 이슈 Close
close #116
