### PR TITLE
Feat/#98 사용자가 검색한 키워드 기록 및 조회 기능 구현

### DIFF
--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -157,6 +157,8 @@
 		3CBE979A29A9041700C0D2FE /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBE979929A9041700C0D2FE /* TabBarView.swift */; };
 		3CBE979C29A904EF00C0D2FE /* ReetTabBarItemButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBE979B29A904EF00C0D2FE /* ReetTabBarItemButton.swift */; };
 		3CBE979E29A90A5800C0D2FE /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBE979D29A90A5800C0D2FE /* TabBarItem.swift */; };
+		3CC9F07B2B7400BB00262B22 /* SearchHistoryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC9F07A2B7400BB00262B22 /* SearchHistoryAction.swift */; };
+		3CC9F07D2B740B7300262B22 /* SearchHistoryListAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC9F07C2B740B7300262B22 /* SearchHistoryListAction.swift */; };
 		3CCB07A829F908C8003EC058 /* CategoryFilterBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCB07A729F908C8003EC058 /* CategoryFilterBottomSheet.swift */; };
 		3CCB07AA29F90D4F003EC058 /* ReetTextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCB07A929F90D4F003EC058 /* ReetTextButton.swift */; };
 		3CCB07AC29F90D90003EC058 /* ReetTextButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCB07AB29F90D90003EC058 /* ReetTextButtonStyle.swift */; };
@@ -363,9 +365,13 @@
 		3CBE979929A9041700C0D2FE /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		3CBE979B29A904EF00C0D2FE /* ReetTabBarItemButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetTabBarItemButton.swift; sourceTree = "<group>"; };
 		3CBE979D29A90A5800C0D2FE /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
+		3CC9F07A2B7400BB00262B22 /* SearchHistoryAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryAction.swift; sourceTree = "<group>"; };
+		3CC9F07C2B740B7300262B22 /* SearchHistoryListAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryListAction.swift; sourceTree = "<group>"; };
 		3CCB07A729F908C8003EC058 /* CategoryFilterBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryFilterBottomSheet.swift; sourceTree = "<group>"; };
 		3CCB07A929F90D4F003EC058 /* ReetTextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetTextButton.swift; sourceTree = "<group>"; };
 		3CCB07AB29F90D90003EC058 /* ReetTextButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetTextButtonStyle.swift; sourceTree = "<group>"; };
+		3CD5586D2B73B715008CD2F8 /* SearchHistory+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchHistory+CoreDataClass.swift"; sourceTree = "<group>"; };
+		3CD5586E2B73B716008CD2F8 /* SearchHistory+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchHistory+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		3CDD84F02B4D05440089F7C9 /* CategoryFilter+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CategoryFilter+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		3CDD84F22B4D05620089F7C9 /* CategoryFilter+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CategoryFilter+CoreDataClass.swift"; sourceTree = "<group>"; };
 		3CE3C47A2A458A180097FB63 /* SearchHistoryTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryTVC.swift; sourceTree = "<group>"; };
@@ -1009,6 +1015,8 @@
 			children = (
 				3CDD84F22B4D05620089F7C9 /* CategoryFilter+CoreDataClass.swift */,
 				3CDD84F02B4D05440089F7C9 /* CategoryFilter+CoreDataProperties.swift */,
+				3CD5586D2B73B715008CD2F8 /* SearchHistory+CoreDataClass.swift */,
+				3CD5586E2B73B716008CD2F8 /* SearchHistory+CoreDataProperties.swift */,
 				3C72D92A2B3401F200AF2190 /* ReetPlace.xcdatamodeld */,
 				3C72D92D2B34043D00AF2190 /* CoreDataManager.swift */,
 			);
@@ -1110,6 +1118,8 @@
 				A4EFC0A2299E724E00B066AF /* ForegroundColorProvider.swift */,
 				3CE5B0ED2B2754FC0080F606 /* BookmarkCardAction.swift */,
 				3CE967472B4C0D27009F86FD /* DetailCategoryChipAction.swift */,
+				3CC9F07A2B7400BB00262B22 /* SearchHistoryAction.swift */,
+				3CC9F07C2B740B7300262B22 /* SearchHistoryListAction.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1387,6 +1397,7 @@
 				3C423F2E29AAF734003B7B7D /* CategoryChipStyle.swift in Sources */,
 				3CCB07AA29F90D4F003EC058 /* ReetTextButton.swift in Sources */,
 				3C2AED582990B3C200E36342 /* UserDefaults+.swift in Sources */,
+				3CC9F07B2B7400BB00262B22 /* SearchHistoryAction.swift in Sources */,
 				0E5A514429F6722700C44701 /* PrivacyPolicyVC.swift in Sources */,
 				3CFBC6FD2A61368300540C7F /* SearchPlaceListRequestModel.swift in Sources */,
 				0E5A514029F6720E00C44701 /* SubmitQnaVC.swift in Sources */,
@@ -1466,6 +1477,7 @@
 				3C2AF0DB29914A8C00E36342 /* AssetsImages.swift in Sources */,
 				3CCB07A829F908C8003EC058 /* CategoryFilterBottomSheet.swift in Sources */,
 				3C2AF0D72991397100E36342 /* NavigationType.swift in Sources */,
+				3CC9F07D2B740B7300262B22 /* SearchHistoryListAction.swift in Sources */,
 				3C2AED5C2990B3C200E36342 /* UIView+.swift in Sources */,
 				3C2AF0DD29914CAA00E36342 /* UIFont+.swift in Sources */,
 				3C04A7C32A4C072B00A31FA3 /* PlaceInfoView.swift in Sources */,

--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		3CBE979E29A90A5800C0D2FE /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBE979D29A90A5800C0D2FE /* TabBarItem.swift */; };
 		3CC9F07B2B7400BB00262B22 /* SearchHistoryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC9F07A2B7400BB00262B22 /* SearchHistoryAction.swift */; };
 		3CC9F07D2B740B7300262B22 /* SearchHistoryListAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC9F07C2B740B7300262B22 /* SearchHistoryListAction.swift */; };
+		3CC9F07F2B74224B00262B22 /* SearchHistoryResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC9F07E2B74224B00262B22 /* SearchHistoryResponseModel.swift */; };
 		3CCB07A829F908C8003EC058 /* CategoryFilterBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCB07A729F908C8003EC058 /* CategoryFilterBottomSheet.swift */; };
 		3CCB07AA29F90D4F003EC058 /* ReetTextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCB07A929F90D4F003EC058 /* ReetTextButton.swift */; };
 		3CCB07AC29F90D90003EC058 /* ReetTextButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCB07AB29F90D90003EC058 /* ReetTextButtonStyle.swift */; };
@@ -371,6 +372,7 @@
 		3CBE979D29A90A5800C0D2FE /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
 		3CC9F07A2B7400BB00262B22 /* SearchHistoryAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryAction.swift; sourceTree = "<group>"; };
 		3CC9F07C2B740B7300262B22 /* SearchHistoryListAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryListAction.swift; sourceTree = "<group>"; };
+		3CC9F07E2B74224B00262B22 /* SearchHistoryResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryResponseModel.swift; sourceTree = "<group>"; };
 		3CCB07A729F908C8003EC058 /* CategoryFilterBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryFilterBottomSheet.swift; sourceTree = "<group>"; };
 		3CCB07A929F90D4F003EC058 /* ReetTextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetTextButton.swift; sourceTree = "<group>"; };
 		3CCB07AB29F90D90003EC058 /* ReetTextButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReetTextButtonStyle.swift; sourceTree = "<group>"; };
@@ -1011,6 +1013,7 @@
 			children = (
 				3CE3CC3C2ACFE0AA0027FB5E /* SearchPlaceKeywordResponseModel.swift */,
 				3C4AE3412AFDFE4B001C8EC6 /* SearchPlaceKeywordRequestModel.swift */,
+				3CC9F07E2B74224B00262B22 /* SearchHistoryResponseModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1558,6 +1561,7 @@
 				A4EFC08B299E488500B066AF /* MyPageVC.swift in Sources */,
 				0EAFCFDC2A2888700023A738 /* SelectBoxTVC.swift in Sources */,
 				A4D09EC8299F984A004DEE97 /* UserInfoVC.swift in Sources */,
+				3CC9F07F2B74224B00262B22 /* SearchHistoryResponseModel.swift in Sources */,
 				3C9256742A1CE26B0011B093 /* CategoryDetailShoppingList.swift in Sources */,
 				0EB76CF12B5E5B3100E3FD51 /* BookmarkListVC.swift in Sources */,
 				A417F66F299E8710005E6DA7 /* UserInfomation.swift in Sources */,

--- a/Reet-Place/Reet-Place/Global/CoreData/CoreDataManager.swift
+++ b/Reet-Place/Reet-Place/Global/CoreData/CoreDataManager.swift
@@ -201,13 +201,14 @@ extension CoreDataManager {
 extension CoreDataManager {
     
     /// 키워드 검색기록 목록 반환
-    func getKeywordHistoryList() -> [String] {
+    func getKeywordHistoryList() -> [SearchHistoryContent] {
         if let searchHistoryObjectList = fetchSearchHistoryObjectList() {
-            var keywordHistoryList: [String] = []
+            var keywordHistoryList: [SearchHistoryContent] = []
             
             searchHistoryObjectList.forEach {
-                if let keyword = $0.value(forKey: #keyPath(SearchHistory.keyword)) as? String {
-                    keywordHistoryList.append(keyword)
+                if let keyword = $0.value(forKey: #keyPath(SearchHistory.keyword)) as? String,
+                   let time = $0.value(forKey: #keyPath(SearchHistory.time)) as? Date {
+                    keywordHistoryList.append(SearchHistoryContent(id: 0, query: keyword, createdAt: time.toString()))
                 }
             }
             return keywordHistoryList
@@ -241,7 +242,8 @@ extension CoreDataManager {
         
         if let entity = getEntityDescription(targetEntity: .searchHistory),
            let objectList = fetchSearchHistoryObjectList() {
-            let keywordHistoryList = getKeywordHistoryList()
+            let searchHistoryContentList = getKeywordHistoryList()
+            let keywordHistoryList = searchHistoryContentList.map { $0.query }
             
             // 최대 저장 개수 초과시 가장 오래된 키워드 삭제
             if objectList.count >= searchHistoryKeywordsMax,

--- a/Reet-Place/Reet-Place/Global/CoreData/ReetPlace.xcdatamodeld/ReetPlace.xcdatamodel/contents
+++ b/Reet-Place/Reet-Place/Global/CoreData/ReetPlace.xcdatamodeld/ReetPlace.xcdatamodel/contents
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F66" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23D56" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="CategoryFilter" representedClassName="CategoryFilter" syncable="YES">
         <attribute name="category" optional="YES" attributeType="String"/>
         <attribute name="subCategory" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
+    </entity>
+    <entity name="SearchHistory" representedClassName=".SearchHistory" syncable="YES" codeGenerationType="class">
+        <attribute name="keyword" optional="YES" attributeType="String"/>
+        <attribute name="time" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="keyword"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
     </entity>
 </model>

--- a/Reet-Place/Reet-Place/Global/CoreData/SearchHistory+CoreDataClass.swift
+++ b/Reet-Place/Reet-Place/Global/CoreData/SearchHistory+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  SearchHistory+CoreDataClass.swift
+//  
+//
+//  Created by Kennadi on 2/7/24.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(SearchHistory)
+public class SearchHistory: NSManagedObject {
+
+}

--- a/Reet-Place/Reet-Place/Global/CoreData/SearchHistory+CoreDataProperties.swift
+++ b/Reet-Place/Reet-Place/Global/CoreData/SearchHistory+CoreDataProperties.swift
@@ -1,0 +1,22 @@
+//
+//  SearchHistory+CoreDataProperties.swift
+//  
+//
+//  Created by Kennadi on 2/7/24.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension SearchHistory {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<SearchHistory> {
+        return NSFetchRequest<SearchHistory>(entityName: CoreDataEntityList.searchHistory.name)
+    }
+
+    @NSManaged public var keyword: String?
+    @NSManaged public var time: Date?
+
+}

--- a/Reet-Place/Reet-Place/Global/Datasource/KeywordHistoryDataSource.swift
+++ b/Reet-Place/Reet-Place/Global/Datasource/KeywordHistoryDataSource.swift
@@ -12,7 +12,7 @@ struct KeywordHistoryDataSource {
 }
 
 extension KeywordHistoryDataSource: SectionModelType {
-    typealias Item = String
+    typealias Item = SearchHistoryContent
     
     init(original: KeywordHistoryDataSource, items: [Item]) {
         self = original

--- a/Reet-Place/Reet-Place/Global/Enum/CoreDataEntityList.swift
+++ b/Reet-Place/Reet-Place/Global/Enum/CoreDataEntityList.swift
@@ -12,6 +12,7 @@ import UIKit
 /// Core Data ReetPlace Persistent Container에 정의되어 있는 Entity 목록
 enum CoreDataEntityList: String {
     case categoryFilter
+    case searchHistory
 }
 
 extension CoreDataEntityList {
@@ -19,6 +20,8 @@ extension CoreDataEntityList {
         switch self {
         case .categoryFilter:
             return "CategoryFilter"
+        case .searchHistory:
+            return "SearchHistory"
         }
     }
 }

--- a/Reet-Place/Reet-Place/Global/Enum/TabPlaceCategoryList.swift
+++ b/Reet-Place/Reet-Place/Global/Enum/TabPlaceCategoryList.swift
@@ -121,24 +121,4 @@ extension TabPlaceCategoryList {
             return []
         }
     }
-    
-    // TODO: - 카테고리별 검색기록 더미 데이터 삭제
-    var list: [String] {
-        switch self {
-        case .all:
-            return ["꾸꾸루꾸 치킨", "CGV 강남점", "반올림 피자샵", "어글리 베이커리", "시현하다 프레임", "인생다섯컷", "숏컷", "입구컷", "더현대", "판교현백", "행복한 백화점", "용산 메가박스"]
-        case .food:
-            return ["꾸꾸루꾸 치킨", "반올림 피자샵"]
-        case .activity:
-            return []
-        case .photoBooth:
-            return ["시현하다 프레임", "인생다섯컷", "숏컷", "입구컷"]
-        case .shopping:
-            return ["더현대", "판교현백", "행복한 백화점"]
-        case .cafe:
-            return ["어글리 베이커리"]
-        case .culture:
-            return ["용산 메가박스", "CGV 강남점"]
-        }
-    }
 }

--- a/Reet-Place/Reet-Place/Global/Network/APIService.swift
+++ b/Reet-Place/Reet-Place/Global/Network/APIService.swift
@@ -18,5 +18,7 @@ protocol APIService {
     
     func requestPut<T: Decodable>(urlResource: URLResource<T>, parameter: Parameters?) -> Observable<Result<T, APIError>>
     
+    func requestDelete<T: Decodable>(urlResource: URLResource<T>) -> Observable<Result<T, APIError>>
+    
 }
 

--- a/Reet-Place/Reet-Place/Global/Protocols/SearchHistoryAction.swift
+++ b/Reet-Place/Reet-Place/Global/Protocols/SearchHistoryAction.swift
@@ -11,6 +11,6 @@ import UIKit
 protocol SearchHistoryAction {
     
     /// 개별 검색기록 지우기 버튼을 클릭했을 때 호출
-    func didTapRemoveButton(keyword: String)
+    func didTapRemoveKeywordButton(searchHistoryContent: SearchHistoryContent)
     
 }

--- a/Reet-Place/Reet-Place/Global/Protocols/SearchHistoryAction.swift
+++ b/Reet-Place/Reet-Place/Global/Protocols/SearchHistoryAction.swift
@@ -1,0 +1,16 @@
+//
+//  SearchHistoryAction.swift
+//  Reet-Place
+//
+//  Created by Kim HeeJae on 2023/12/18.
+//
+
+import UIKit
+
+/// SearchHistoryTVC와 관련된 작업 등을 정의
+protocol SearchHistoryAction {
+    
+    /// 개별 검색기록 지우기 버튼을 클릭했을 때 호출
+    func didTapRemoveButton(keyword: String)
+    
+}

--- a/Reet-Place/Reet-Place/Global/Protocols/SearchHistoryListAction.swift
+++ b/Reet-Place/Reet-Place/Global/Protocols/SearchHistoryListAction.swift
@@ -11,6 +11,6 @@ import UIKit
 protocol SearchHistoryListAction {
     
     /// 검색기록 키워드를 클릭했을 때 호출
-    func didTapKeyword(keyword: String)
+    func didTapKeyword(searchHistoryContent: SearchHistoryContent)
     
 }

--- a/Reet-Place/Reet-Place/Global/Protocols/SearchHistoryListAction.swift
+++ b/Reet-Place/Reet-Place/Global/Protocols/SearchHistoryListAction.swift
@@ -1,0 +1,16 @@
+//
+//  SearchHistoryListAction.swift
+//  Reet-Place
+//
+//  Created by Kim HeeJae on 2023/12/18.
+//
+
+import UIKit
+
+/// SearchHistoryTVC와 관련된 작업 등을 정의
+protocol SearchHistoryListAction {
+    
+    /// 검색기록 키워드를 클릭했을 때 호출
+    func didTapKeyword(keyword: String)
+    
+}

--- a/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceResultListCVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Cell/PlaceResultListCVC.swift
@@ -74,8 +74,8 @@ extension PlaceResultListCVC {
         
         var simpleAddress: String = .empty
         let addressList = placeResultInfo.lotNumberAddress.split(separator: " ")
-        if let city = addressList[safe: 11],
-           let dong = addressList[safe: 21] {
+        if let city = addressList[safe: 1],
+           let dong = addressList[safe: 2] {
             simpleAddress = city + " " + dong
         }
         

--- a/Reet-Place/Reet-Place/Screen/Home/Search/Cell/SearchHistoryListCVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/Cell/SearchHistoryListCVC.swift
@@ -149,12 +149,22 @@ extension SearchHistoryListCVC {
             .bind(to: searchHistoryTableView.rx.items(dataSource: dataSource))
             .disposed(by: bag)
         
-        viewModel.output.searchHistory.isUpdated
+        viewModel.output.searchHistory.isNeedUpdated
             .withUnretained(self)
-            .subscribe(onNext: { owner, isUpdated in
-                if isUpdated {
+            .subscribe(onNext: { owner, isNeedUpdated in
+                if isNeedUpdated {
                     owner.searchHistoryTableView.scrollToTop()
-                    viewModel.updateKeywordHistory()
+                    viewModel.updateSearchHistory()
+                    owner.searchHistoryTableView.reloadData()
+                }
+            })
+            .disposed(by: bag)
+        
+        viewModel.output.searchHistory.isUpdatedWithoutScroll
+            .withUnretained(self)
+            .subscribe(onNext: { owner, isDeleteSuccess in
+                if isDeleteSuccess {
+                    viewModel.updateSearchHistory()
                     owner.searchHistoryTableView.reloadData()
                 }
             })

--- a/Reet-Place/Reet-Place/Screen/Home/Search/Cell/SearchHistoryListCVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/Cell/SearchHistoryListCVC.swift
@@ -53,7 +53,7 @@ class SearchHistoryListCVC : BaseCollectionViewCell {
     
     var bag = DisposeBag()
     
-    var delegateSearchHistoryListAction: SearchHistoryListAction?
+    private var delegateSearchHistoryListAction: SearchHistoryListAction?
     
     // MARK: - Life Cycle
     
@@ -128,14 +128,15 @@ extension SearchHistoryListCVC {
         let dataSource = RxTableViewSectionedReloadDataSource<KeywordHistoryDataSource> { _,
             tableView,
             indexPath,
-            keyword in
+            searchHistoryContent in
 
             guard let cell = tableView
                 .dequeueReusableCell(withIdentifier: SearchHistoryTVC.className,
                                      for: indexPath) as? SearchHistoryTVC else {
                 fatalError("Cannot deqeue cells named SearchHistoryTVC")
             }
-            cell.configureSearchHistoryTVC(keywordHistory: keyword.description, delegateSearchHistoryAction: delegate)
+            cell.configureSearchHistoryTVC(searchHistoryContent: searchHistoryContent,
+                                           delegateSearchHistoryAction: delegate)
 
             return cell
         }
@@ -166,11 +167,11 @@ extension SearchHistoryListCVC {
             })
             .disposed(by: bag)
         
-        searchHistoryTableView.rx.modelSelected(String.self)
+        searchHistoryTableView.rx.modelSelected(SearchHistoryContent.self)
             .withUnretained(self)
-            .bind(onNext: { owner, keyword in
-                owner.delegateSearchHistoryListAction?.didTapKeyword(keyword: keyword)
-                viewModel.output.searchHistory.isUpdated.accept(true)
+            .bind(onNext: { owner, searchHistoryContent in
+                owner.delegateSearchHistoryListAction?.didTapKeyword(searchHistoryContent: searchHistoryContent)
+                viewModel.output.searchHistory.isNeedUpdated.accept(true)
             })
             .disposed(by: bag)
         

--- a/Reet-Place/Reet-Place/Screen/Home/Search/Cell/SearchHistoryTVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/Cell/SearchHistoryTVC.swift
@@ -43,7 +43,8 @@ class SearchHistoryTVC: BaseTableViewCell {
     
     var bag = DisposeBag()
     
-    var delegateSearchHistoryAction: SearchHistoryAction?
+    private var searchHistoryContent: SearchHistoryContent?
+    private var delegateSearchHistoryAction: SearchHistoryAction?
     
     // MARK: - Life Cycle
     
@@ -68,9 +69,12 @@ class SearchHistoryTVC: BaseTableViewCell {
     
     // MARK: - Function
     
-    func configureSearchHistoryTVC(keywordHistory: String, delegateSearchHistoryAction: SearchHistoryAction) {
+    func configureSearchHistoryTVC(searchHistoryContent: SearchHistoryContent, 
+                                   delegateSearchHistoryAction: SearchHistoryAction) {
+        self.searchHistoryContent = searchHistoryContent
         self.delegateSearchHistoryAction = delegateSearchHistoryAction
-        keywordLabel.text = keywordHistory
+        
+        keywordLabel.text = searchHistoryContent.query
     }
     
 }
@@ -124,8 +128,8 @@ extension SearchHistoryTVC {
             .withUnretained(self)
             .bind(onNext: { owner, _ in
                 if let delegate = owner.delegateSearchHistoryAction,
-                   let keyword = owner.keywordLabel.text {
-                    delegate.didTapRemoveButton(keyword: keyword)
+                   let searchHistoryContent = owner.searchHistoryContent {
+                    delegate.didTapRemoveKeywordButton(searchHistoryContent: searchHistoryContent)
                 }
             })
             .disposed(by: bag)

--- a/Reet-Place/Reet-Place/Screen/Home/Search/Model/SearchHistoryResponseModel.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/Model/SearchHistoryResponseModel.swift
@@ -1,0 +1,21 @@
+//
+//  SearchHistoryResponseModel.swift
+//  Reet-Place
+//
+//  Created by Kim HeeJae on 2023/12/18.
+//
+
+import Foundation
+
+// MARK: - SearchHistory ResponseModel
+
+struct SearchHistoryResponseModel: Codable {
+    let contents: [SearchHistoryContent]
+}
+
+// MARK: - SearchHistory Content
+
+struct SearchHistoryContent: Codable {
+    let id: Int
+    let query, createdAt: String
+}

--- a/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
@@ -91,6 +91,7 @@ class SearchVC: BaseViewController {
             $0.isPagingEnabled = true
             $0.showsHorizontalScrollIndicator = false
             $0.register(SearchHistoryListCVC.self, forCellWithReuseIdentifier: SearchHistoryListCVC.className)
+            $0.isScrollEnabled = false // TODO: - '검색 카테고리 메뉴바' 제거를 고려한 임시 스크롤 금지 수정
         }
     
     private let searchResultTableView = UITableView(frame: .zero, style: .plain)
@@ -295,12 +296,17 @@ extension SearchVC {
         }
         
         historyCategoryTabBarView.snp.makeConstraints {
-            $0.top.equalTo(titleStackView.snp.bottom).offset(16.0)
+//            $0.top.equalTo(titleStackView.snp.bottom).offset(16.0)
+            $0.top.equalTo(titleStackView.snp.bottom).offset(0.0) // TODO: - '검색 카테고리 메뉴바' 제거를 고려한 임시 레이아웃 수정
             $0.horizontalEdges.equalTo(view)
+        }
+        historyCategoryTabBarView.menuBarCollectionView.snp.updateConstraints {
+            $0.height.equalTo(0.0) // TODO: - 1차 출시는 카테고리 구별 없는 검색기록으로 진행. 추후 업데이트 반영 필요
         }
         
         searchHistoryListCollectionView.snp.makeConstraints {
-            $0.top.equalTo(historyCategoryTabBarView.snp.bottom).offset(16.0)
+//            $0.top.equalTo(historyCategoryTabBarView.snp.bottom).offset(16.0) // TODO: - '검색 카테고리 메뉴바' 제거를 고려한 임시 레이아웃 수정
+            $0.top.equalTo(historyCategoryTabBarView.snp.bottom).offset(0.0)
             $0.horizontalEdges.bottom.equalTo(view)
         }
         

--- a/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
@@ -377,9 +377,7 @@ extension SearchVC {
         removeAllKeywordButton.rx.tap
             .withUnretained(self)
             .bind(onNext: { owner, _ in
-                if CoreDataManager.shared.deleteAllSearchKeyword() {
-                    owner.viewModel.output.searchHistory.isUpdated.accept(true)
-                }
+                owner.viewModel.deleteSearchHistory()
             })
             .disposed(by: bag)
         
@@ -661,8 +659,8 @@ extension SearchVC: BookmarkCardAction {
 
 extension SearchVC: SearchHistoryListAction {
     
-    func didTapKeyword(keyword: String) {
-        searchTextField.text = keyword
+    func didTapKeyword(searchHistoryContent: SearchHistoryContent) {
+        searchTextField.text = searchHistoryContent.query
         startSearchPlaceKeyword()
     }
     
@@ -672,10 +670,8 @@ extension SearchVC: SearchHistoryListAction {
 
 extension SearchVC: SearchHistoryAction {
     
-    func didTapRemoveButton(keyword: String) {
-        if CoreDataManager.shared.deleteSearchKeyword(targetKeyword: keyword) {
-            viewModel.output.searchHistory.isUpdated.accept(true)
-        }
+    func didTapRemoveKeywordButton(searchHistoryContent: SearchHistoryContent) {
+        viewModel.deleteKeyword(searchHistoryContent: searchHistoryContent)
     }
     
 }

--- a/Reet-Place/Reet-Place/Screen/Home/Search/ViewModel/SearchVM.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/ViewModel/SearchVM.swift
@@ -36,7 +36,7 @@ final class SearchVM: BaseViewModel {
     
     /// 장소검색 키워드 히스토리
     struct SearchHistory {
-        var keywordList: BehaviorRelay<Array<String>> = BehaviorRelay(value: CoreDataManager.shared.getKeywordHistoryList())
+        var keywordList: PublishRelay<Array<SearchHistoryContent>> = PublishRelay<Array<SearchHistoryContent>>()
         var isUpdated: BehaviorRelay<Bool> = BehaviorRelay(value: false)
         
         var list: BehaviorRelay<Array<TabPlaceCategoryList>> = BehaviorRelay(value: TabPlaceCategoryList.allCases)

--- a/Reet-Place/Reet-Place/Screen/Home/Search/ViewModel/SearchVM.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/ViewModel/SearchVM.swift
@@ -22,6 +22,8 @@ final class SearchVM: BaseViewModel {
     
     struct Input {}
     struct Output {
+        var isLoginUser = KeychainManager.shared.read(for: .accessToken) != nil
+        
         var categoryHistoryList: BehaviorRelay<Array<TabPlaceCategoryList>> = BehaviorRelay(value: TabPlaceCategoryList.allCases)
         var tabPlaceCategoryDataSources: Observable<Array<TabPlaceCategoryListDataSource>> {
             categoryHistoryList.map { [TabPlaceCategoryListDataSource(items: $0)] }
@@ -35,6 +37,7 @@ final class SearchVM: BaseViewModel {
     /// 장소검색 키워드 히스토리
     struct SearchHistory {
         var keywordList: BehaviorRelay<Array<String>> = BehaviorRelay(value: CoreDataManager.shared.getKeywordHistoryList())
+        var isUpdated: BehaviorRelay<Bool> = BehaviorRelay(value: false)
         
         var list: BehaviorRelay<Array<TabPlaceCategoryList>> = BehaviorRelay(value: TabPlaceCategoryList.allCases)
         var dataSource: Observable<Array<SearchHistoryListDataSource>> {
@@ -62,6 +65,12 @@ final class SearchVM: BaseViewModel {
     
     deinit {
         bag = DisposeBag()
+    }
+    
+    // MARK: - Functions
+    
+    func updateKeywordHistory() {
+        output.searchHistory.keywordList.accept(CoreDataManager.shared.getKeywordHistoryList())
     }
 }
 

--- a/Reet-Place/Reet-Place/Screen/Home/Search/ViewModel/SearchVM.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/ViewModel/SearchVM.swift
@@ -37,7 +37,8 @@ final class SearchVM: BaseViewModel {
     /// 장소검색 키워드 히스토리
     struct SearchHistory {
         var keywordList: PublishRelay<Array<SearchHistoryContent>> = PublishRelay<Array<SearchHistoryContent>>()
-        var isUpdated: BehaviorRelay<Bool> = BehaviorRelay(value: false)
+        var isNeedUpdated: BehaviorRelay<Bool> = BehaviorRelay(value: false)
+        var isUpdatedWithoutScroll: PublishRelay<Bool> = PublishRelay()
         
         var list: BehaviorRelay<Array<TabPlaceCategoryList>> = BehaviorRelay(value: TabPlaceCategoryList.allCases)
         var dataSource: Observable<Array<SearchHistoryListDataSource>> {
@@ -69,8 +70,34 @@ final class SearchVM: BaseViewModel {
     
     // MARK: - Functions
     
-    func updateKeywordHistory() {
-        output.searchHistory.keywordList.accept(CoreDataManager.shared.getKeywordHistoryList())
+    /// 로그인 유무에 따른 사용자의 검색기록 목록 조회 요청
+    func updateSearchHistory() {
+        switch output.isLoginUser {
+        case true:
+            requestSearchHistory()
+        case false:
+            output.searchHistory.keywordList.accept(CoreDataManager.shared.getKeywordHistoryList())
+        }
+    }
+    
+    /// 로그인 유무에 따른 사용자의 전체 검색기록 삭제
+    func deleteSearchHistory() {
+        switch output.isLoginUser {
+        case true:
+            requestDeleteSearchHistory()
+        case false:
+            output.searchHistory.isNeedUpdated.accept(CoreDataManager.shared.deleteAllSearchKeyword())
+        }
+    }
+    
+    /// 로그인 유무에 따른 특정 키워드 삭제 요청
+    func deleteKeyword(searchHistoryContent: SearchHistoryContent) {
+        switch output.isLoginUser {
+        case true:
+            requestDeleteKeyword(keywordID: searchHistoryContent.id)
+        case false:
+            output.searchHistory.isUpdatedWithoutScroll.accept(CoreDataManager.shared.deleteSearchKeyword(targetKeyword: searchHistoryContent.query))
+        }
     }
 }
 
@@ -86,10 +113,75 @@ extension SearchVM: Output {
     func bindOutput() {}
 }
 
-// MARK: - Networking
+// MARK: - Networking SearchHistory
 
 extension SearchVM {
     
+    /// 로그인한 사용자의 검색기록 목록 조회
+    func requestSearchHistory() {
+        let path = "/api/search/history"
+        let resource = URLResource<SearchHistoryResponseModel>(path: path)
+        
+        apiSession.requestGet(urlResource: resource)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, result in
+                switch result {
+                case .success(let data):
+                    owner.output.searchHistory.keywordList.accept(data.contents)
+                case .failure(let error):
+                    owner.apiError.onNext(error)
+                }
+            })
+            .disposed(by: bag)
+    }
+    
+    /// 전체 검색기록 삭제
+    func requestDeleteSearchHistory() {
+        let path = "/api/search/history"
+        let resource = URLResource<EmptyEntity>(path: path)
+        
+        apiSession.requestDelete(urlResource: resource)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, result in
+                switch result {
+                case .success(_):
+                    owner.output.searchHistory.isNeedUpdated.accept(true)
+                case .failure(let error):
+                    owner.output.searchHistory.isNeedUpdated.accept(false)
+                    owner.apiError.onNext(error)
+                }
+            })
+            .disposed(by: bag)
+    }
+    
+    /// 선택한 키워드 삭제
+    func requestDeleteKeyword(keywordID searchId: Int) {
+        let searchId = String(searchId)
+        
+        let path = "/api/search/history/\(searchId)"
+        let resource = URLResource<EmptyEntity>(path: path)
+        
+        apiSession.requestDelete(urlResource: resource)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, result in
+                switch result {
+                case .success(_):
+                    owner.output.searchHistory.isUpdatedWithoutScroll.accept(true)
+                case .failure(let error):
+                    owner.output.searchHistory.isUpdatedWithoutScroll.accept(false)
+                    owner.apiError.onNext(error)
+                }
+            })
+            .disposed(by: bag)
+    }
+    
+}
+
+// MARK: - Networking SearchPlaceKeyword
+
+extension SearchVM {
+    
+    /// 주어진 좌표를 중심으로 해당 키워드와 연관된 장소목록 조회
     func requestSearchPlaceKeyword(placeKeyword: SearchPlaceKeywordRequestModel) {
         let path = "/api/places/search"
         let resource = URLResource<SearchPlaceKeywordResponseModel>(path: path)

--- a/Reet-Place/Reet-Place/Screen/Home/Search/ViewModel/SearchVM.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/ViewModel/SearchVM.swift
@@ -34,6 +34,8 @@ final class SearchVM: BaseViewModel {
     
     /// 장소검색 키워드 히스토리
     struct SearchHistory {
+        var keywordList: BehaviorRelay<Array<String>> = BehaviorRelay(value: CoreDataManager.shared.getKeywordHistoryList())
+        
         var list: BehaviorRelay<Array<TabPlaceCategoryList>> = BehaviorRelay(value: TabPlaceCategoryList.allCases)
         var dataSource: Observable<Array<SearchHistoryListDataSource>> {
             list.map { [SearchHistoryListDataSource(items: $0)] }

--- a/Reet-Place/Reet-Place/Screen/Home/ViewModel/HomeVM.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewModel/HomeVM.swift
@@ -65,6 +65,7 @@ extension HomeVM: Output {
 
 extension HomeVM {
     
+    /// 주어진 좌표를 중심으로 해당 카테고리와 관련된 장소목록 조회
     func requestSearchPlaces(category: PlaceCategoryList, latitude: String, longitude: String) {
         let path = "/api/places"
         let resource = URLResource<SearchPlaceListResponseModel>(path: path)


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
비로그인/로그인 사용자의 키워드 검색 내용을 기록하고 조회하는 기능을 구현하였습니다.
- 로그인 사용자의 경우 서버와의 연결을 통해 검색기록을 조회하고 개별 혹은 전체 키워드를 지울 수 있게 네트워크 코드를 추가하였습니다
- 비로그인 사용자의 경우 CoreData를 사용하여 디바이스 로컬에 저장하고 조회하는 방식으로 기능을 구현하였습니다

## 📋 변경 사항
### 검색기록 카테고리 탭바
- 이전 회의내용에 따라 1차 출시까지 검색기록의 카테고리별 분류 기능을 보류하고 단순한 사용자 키워드 검색내역 표시로 구현하기 위해 탭바를 UI상 **표시되지 않게** 조치하였습니다

### CoreData
- CoreData 엔티티 항목에 검색기록 관리를 위한 `SearchHistory` Entity가 추가되었습니다

### APISession
- 키워드 삭제 등의 기능구현을 위해 HTTP Method의 `DELETE` 방식과 관련된 서버코드를 추가하였습니다

## 🔍 Code Review
비로그인 환경에서 **`전체지우기`** 버튼을 클릭하면 기능은 정상작동하지만 **`전체지우기`** 버튼이 비활성화(isEnabled = false)가 되지 않는 문제가 있습니다. 키워드를 일일이 개별로 삭제하면 같은 방식으로 버튼이 비활성화(isEnabled = false) 되면서 **`전체지우기`** 버튼 디자인이 비활성화 형태로 변경되어서 같은 코드에서 왜 다른 결과가 나오는지 몰라 문제를 해결하지 못했습니다 🥲
<img src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/26570294/a9681e15-b996-46c6-b5d6-27ef7403b80e" width="300px" />

## 📸 ScreenShot
<img src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/26570294/85bf84fa-0086-4a75-9a9d-3918edfdab6f" width="300px" />

### 연결된 이슈 Close
close #98 