### PR TITLE
Feat/#122 위치 권한 검사 및 권한설정 유도 팝업창 설정

### DIFF
--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		3CF3EAB82A3C29B9003B4DE2 /* CategoryDetailRestaurantList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF3EAB72A3C29B9003B4DE2 /* CategoryDetailRestaurantList.swift */; };
 		3CF3EABA2A3C2A36003B4DE2 /* CategoryDetailBarList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF3EAB92A3C2A36003B4DE2 /* CategoryDetailBarList.swift */; };
 		3CF3EABC2A3C2FA5003B4DE2 /* CategoryDetailHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF3EABB2A3C2FA5003B4DE2 /* CategoryDetailHeaderView.swift */; };
+		3CF488AB2B836A1E00A3381C /* SearchPlaceAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF488AA2B836A1E00A3381C /* SearchPlaceAction.swift */; };
 		3CF70D022A1BA82300523A74 /* LeftAlignedCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF70D012A1BA82300523A74 /* LeftAlignedCollectionViewFlowLayout.swift */; };
 		3CFBC6FB2A6134C300540C7F /* SearchPlaceListResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFBC6FA2A6134C300540C7F /* SearchPlaceListResponseModel.swift */; };
 		3CFBC6FD2A61368300540C7F /* SearchPlaceListRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFBC6FC2A61368300540C7F /* SearchPlaceListRequestModel.swift */; };
@@ -394,6 +395,7 @@
 		3CF3EAB72A3C29B9003B4DE2 /* CategoryDetailRestaurantList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDetailRestaurantList.swift; sourceTree = "<group>"; };
 		3CF3EAB92A3C2A36003B4DE2 /* CategoryDetailBarList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDetailBarList.swift; sourceTree = "<group>"; };
 		3CF3EABB2A3C2FA5003B4DE2 /* CategoryDetailHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDetailHeaderView.swift; sourceTree = "<group>"; };
+		3CF488AA2B836A1E00A3381C /* SearchPlaceAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPlaceAction.swift; sourceTree = "<group>"; };
 		3CF70D012A1BA82300523A74 /* LeftAlignedCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftAlignedCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		3CFBC6FA2A6134C300540C7F /* SearchPlaceListResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPlaceListResponseModel.swift; sourceTree = "<group>"; };
 		3CFBC6FC2A61368300540C7F /* SearchPlaceListRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPlaceListRequestModel.swift; sourceTree = "<group>"; };
@@ -1130,6 +1132,7 @@
 				3CE967472B4C0D27009F86FD /* DetailCategoryChipAction.swift */,
 				3CC9F07A2B7400BB00262B22 /* SearchHistoryAction.swift */,
 				3CC9F07C2B740B7300262B22 /* SearchHistoryListAction.swift */,
+				3CF488AA2B836A1E00A3381C /* SearchPlaceAction.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1509,6 +1512,7 @@
 				A4EFC09B299E6C9900B066AF /* LoginView.swift in Sources */,
 				3C2AED5E2990B3C200E36342 /* UIStackView+.swift in Sources */,
 				0EFE7C3F29B05D310051E72D /* ReetTextField.swift in Sources */,
+				3CF488AB2B836A1E00A3381C /* SearchPlaceAction.swift in Sources */,
 				0E05EFFF2A4C75C3008A20F4 /* OnboardingVC.swift in Sources */,
 				0E502B712A91968A002C71F2 /* BookmarkListRequestModel.swift in Sources */,
 				A4EFC099299E608500B066AF /* BaseNavigationViewController.swift in Sources */,

--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -1753,9 +1753,9 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = C9U8778A7W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reet-Place/Support/Info.plist";
-				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "사용자의 위치를 받습니다";
-				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "사용자의 위치를 받습니다";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "사용자의 위치를 받습니다";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "원활한 지도 사용과 위치 기반 장소 검색을 위해 사용자의 위치 정보가 필요합니다.";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "원활한 지도 사용과 위치 기반 장소 검색을 위해 사용자의 위치 정보가 필요합니다.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "원활한 지도 사용과 위치 기반 장소 검색을 위해 사용자의 위치 정보가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen.storyboard;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -1795,9 +1795,9 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = C9U8778A7W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reet-Place/Support/Info.plist";
-				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "사용자의 위치를 받습니다";
-				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "사용자의 위치를 받습니다";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "사용자의 위치를 받습니다";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "원활한 지도 사용과 위치 기반 장소 검색을 위해 사용자의 위치 정보가 필요합니다.";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "원활한 지도 사용과 위치 기반 장소 검색을 위해 사용자의 위치 정보가 필요합니다.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "원활한 지도 사용과 위치 기반 장소 검색을 위해 사용자의 위치 정보가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen.storyboard;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;

--- a/Reet-Place/Reet-Place/Global/Assets/en.lproj/Localizable.strings
+++ b/Reet-Place/Reet-Place/Global/Assets/en.lproj/Localizable.strings
@@ -179,11 +179,14 @@ StartReetPlace = "ReetPlace 시작하기";
 DeleteBookmarkPopUpTitle = "북마크를 해제할까요?";
 WithdrawalPopUpTitle = "정말 탈퇴하시겠어요?";
 GoToLoginPopUpTitle = "로그인이 필요한 서비스에요!";
+AuthorizeLocationPopUpTitle = "위치 권한설정";
 
 DeleteBookmarkPopUpDesc = "북마크를 해제하시면,\n입력하셨던 내용이 전부 사라집니다.";
 WithdrawalPopUpDesc = "탈퇴 이후 당신의 장소들은\n다시 복구되지 않아요.";
 GoToLoginPopUpDesc = "로그인하고 장소들을 저장하고,\n나만의 지도를 채워보세요.";
+AuthorizeLocationPopUpDesc = "현재 위치를 알기 위해서는\n위치 권한설정이 필요해요";
 
 DeleteBookmarkPopUpConfirmTitle = "해제";
 WithdrawalPopUpConfirmTitle = "탈퇴";
 GoToLoginPopUpConfirmTitle = "로그인하기";
+AuthorizeLocationPopUpConfirmTitle = "설정하기";

--- a/Reet-Place/Reet-Place/Global/Assets/en.lproj/Localizable.strings
+++ b/Reet-Place/Reet-Place/Global/Assets/en.lproj/Localizable.strings
@@ -184,7 +184,7 @@ AuthorizeLocationPopUpTitle = "위치 권한설정";
 DeleteBookmarkPopUpDesc = "북마크를 해제하시면,\n입력하셨던 내용이 전부 사라집니다.";
 WithdrawalPopUpDesc = "탈퇴 이후 당신의 장소들은\n다시 복구되지 않아요.";
 GoToLoginPopUpDesc = "로그인하고 장소들을 저장하고,\n나만의 지도를 채워보세요.";
-AuthorizeLocationPopUpDesc = "현재 위치를 알기 위해서는\n위치 권한설정이 필요해요";
+AuthorizeLocationPopUpDesc = "원활한 지도 사용과 위치 기반 장소 검색을 위해 사용자의 위치 정보가 필요합니다.";
 
 DeleteBookmarkPopUpConfirmTitle = "해제";
 WithdrawalPopUpConfirmTitle = "탈퇴";

--- a/Reet-Place/Reet-Place/Global/Enum/PopUpType.swift
+++ b/Reet-Place/Reet-Place/Global/Enum/PopUpType.swift
@@ -11,6 +11,7 @@ enum PopUpType {
     case deleteBookmark
     case withdrawal
     case goToLogin
+    case authorizeLocation
 }
 
 extension PopUpType {
@@ -22,6 +23,8 @@ extension PopUpType {
             return "WithdrawalPopUpTitle".localized
         case .goToLogin:
             return "GoToLoginPopUpTitle".localized
+        case .authorizeLocation:
+            return "AuthorizeLocationPopUpTitle".localized
         }
     }
     
@@ -30,6 +33,8 @@ extension PopUpType {
         case .deleteBookmark:
             return AssetFonts.h4.font
         case .withdrawal, .goToLogin:
+            return AssetFonts.subtitle1.font
+        case .authorizeLocation:
             return AssetFonts.subtitle1.font
         }
     }
@@ -42,6 +47,8 @@ extension PopUpType {
             return "WithdrawalPopUpDesc".localized
         case .goToLogin:
             return "GoToLoginPopUpDesc".localized
+        case .authorizeLocation:
+            return "AuthorizeLocationPopUpDesc".localized
         }
     }
     
@@ -51,6 +58,8 @@ extension PopUpType {
             return AssetFonts.body2.font
         case .withdrawal, .goToLogin:
             return AssetFonts.body1.font
+        case .authorizeLocation:
+            return AssetFonts.body1.font
         }
     }
     
@@ -58,7 +67,7 @@ extension PopUpType {
         switch self {
         case .deleteBookmark:
             return AssetColors.error
-        case .withdrawal, .goToLogin:
+        case .withdrawal, .goToLogin, .authorizeLocation:
             return AssetColors.black
         }
     }
@@ -71,6 +80,8 @@ extension PopUpType {
             return "WithdrawalPopUpConfirmTitle".localized
         case .goToLogin:
             return "GoToLoginPopUpConfirmTitle".localized
+        case .authorizeLocation:
+            return "AuthorizeLocationPopUpConfirmTitle".localized
         }
     }
     

--- a/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
+++ b/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
@@ -139,7 +139,7 @@ extension UIViewController {
         
     }
     
-    /// Pop Up 노출
+    /// 릿플 스타일(ReetPopUp) 팝업창 노출
     func showPopUp(popUpType: PopUpType, targetVC: UIViewController, confirmBtnAction: Selector) {
         let popUpVC = ReetPopUp()
         
@@ -181,6 +181,13 @@ extension UIViewController {
         showPopUp(popUpType: .authorizeLocation,
                   targetVC: self,
                   confirmBtnAction: #selector(openReetPlaceSettings))
+    }
+    
+    /// 아이폰 설정 앱 - Reet-Place의 설정 화면으로 이동
+    @objc private func openReetPlaceSettings() {
+        if let appSetting = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(appSetting)
+        }
     }
     
 }

--- a/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
+++ b/Reet-Place/Reet-Place/Global/Extension/UIViewController+.swift
@@ -176,4 +176,11 @@ extension UIViewController {
         return rootVC
     }
     
+    /// 현재위치 권한설정 알람 팝업창 표시
+    func showPopUpAuthorizeLocation(){
+        showPopUp(popUpType: .authorizeLocation,
+                  targetVC: self,
+                  confirmBtnAction: #selector(openReetPlaceSettings))
+    }
+    
 }

--- a/Reet-Place/Reet-Place/Global/Protocols/SearchPlaceAction.swift
+++ b/Reet-Place/Reet-Place/Global/Protocols/SearchPlaceAction.swift
@@ -1,0 +1,16 @@
+//
+//  SearchPlaceAction.swift
+//  Reet-Place
+//
+//  Created by Kim HeeJae on 2024/02/17.
+//
+
+import UIKit
+import CoreLocation
+
+/// 장소 검색과 관련된 함수를 정의
+protocol SearchPlaceAction {
+    
+    func getLocationManager() -> CLLocationManager
+    
+}

--- a/Reet-Place/Reet-Place/Global/Utils/KeychainManager.swift
+++ b/Reet-Place/Reet-Place/Global/Utils/KeychainManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import NMapsMap
 
 final class KeychainManager {
     
@@ -130,6 +131,24 @@ extension KeychainManager {
         }
     }
     
+    /// 네이버 지도 상의 마지막 카메라 위치 값을 저장
+    func saveLastPosition(locationCoordinate: NMGLatLng) {
+        save(key: .lastPositionLat, value: locationCoordinate.lat.description)
+        save(key: .lastPositionLng, value: locationCoordinate.lng.description)
+    }
+    
+    /// 사용자가 사용했던 네이버 지도 상의 마지막 카메라 위치 값을 조회
+    func readLastPosition() -> NMGLatLng? {
+        if let latitude = read(for: .lastPositionLat),
+           let longitude = read(for: .lastPositionLng),
+           let latitude = Double(latitude),
+           let longitude = Double(longitude) {
+            return NMGLatLng(lat: Double(latitude), lng: Double(longitude))
+        } else {
+            return nil
+        }
+    }
+    
 }
 
 // MARK: - Keys
@@ -150,6 +169,9 @@ extension KeychainManager {
       case userName
       case memberID
       case email
+      
+      case lastPositionLat
+      case lastPositionLng
   }
   
 }

--- a/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
@@ -16,11 +16,6 @@ import RxDataSources
 import Then
 import SnapKit
 
-/// 장소 검색과 관련된 함수를 정의
-protocol SearchPlaceAction {
-    func getCurrentLocationCoordinate() -> CLLocationCoordinate2D?
-}
-
 class SearchVC: BaseViewController {
     
     // MARK: - UI components

--- a/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/Search/ViewController/SearchVC.swift
@@ -196,21 +196,27 @@ class SearchVC: BaseViewController {
     }
     
     private func requestSearchPlaceKeyword(requestPage: Int) {
-        if let curLocationCoordinate = delegateSearchPlaceAction?.getCurrentLocationCoordinate() {
-            if let keyword = searchTextField.text?.trimmingCharacters(in: .whitespaces), !keyword.isEmpty {
-                searchTextField.text = keyword
-                
-                if !viewModel.output.isLoginUser {
-                    CoreDataManager.shared.saveSearchKeyword(toSaveKeyword: keyword)
+        if let locationManager = delegateSearchPlaceAction?.getLocationManager() {
+            switch locationManager.authorizationStatus {
+            case .authorizedAlways, .authorizedWhenInUse:
+                if let keyword = searchTextField.text?.trimmingCharacters(in: .whitespaces), !keyword.isEmpty,
+                   let coordinate = locationManager.location?.coordinate {
+                    searchTextField.text = keyword
+                    
+                    if !viewModel.output.isLoginUser {
+                        CoreDataManager.shared.saveSearchKeyword(toSaveKeyword: keyword)
+                    }
+                    
+                    viewModel.requestSearchPlaceKeyword(placeKeyword: SearchPlaceKeywordRequestModel(lat: coordinate.latitude,
+                                                                                                     lng: coordinate.longitude,
+                                                                                                     placeKeword: keyword,
+                                                                                                     page: requestPage))
                 }
-                
-                viewModel.requestSearchPlaceKeyword(placeKeyword: SearchPlaceKeywordRequestModel(lat: curLocationCoordinate.latitude,
-                                                                                                 lng: curLocationCoordinate.longitude,
-                                                                                                 placeKeword: keyword,
-                                                                                                 page: requestPage))
+            case .notDetermined:
+                locationManager.requestWhenInUseAuthorization()
+            default:
+                showPopUpAuthorizeLocation()
             }
-        } else {
-            self.showErrorAlert("FailGetCurLocationCoordinate".localized)
         }
     }
     

--- a/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
+++ b/Reet-Place/Reet-Place/Screen/Home/ViewController/HomeVC.swift
@@ -491,7 +491,7 @@ extension HomeVC: NMFMapViewCameraDelegate {
         
         // 현재 지도 위치가 네이버 사옥(지도의 최초 초기화 위치)이 아닌 경우에만 현재 지도의 마지막 위치 저장
         if !(naverLocation.lat == curMapViewLocation.lat &&
-            naverLocation.lng == curMapViewLocation.lng) {
+             naverLocation.lng == curMapViewLocation.lng) {
             KeychainManager.shared.saveLastPosition(locationCoordinate: curMapViewLocation)
         }
     }

--- a/Reet-Place/Reet-Place/Support/Info.plist
+++ b/Reet-Place/Reet-Place/Support/Info.plist
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>사용자의 위치를 받습니다</string>
+	<string>원활한 지도 사용과 위치 기반 장소 검색을 위해 사용자의 위치 정보가 필요합니다.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>사용자의 위치를 받습니다</string>
+	<string>원활한 지도 사용과 위치 기반 장소 검색을 위해 사용자의 위치 정보가 필요합니다.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>사용자의 위치를 받습니다</string>
+	<string>원활한 지도 사용과 위치 기반 장소 검색을 위해 사용자의 위치 정보가 필요합니다.</string>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
로그인 이후 현재 `위치조회 권한 설정`을 할 수 있게 하는 UX가 없는 문제와 관련된 **QA 피드백의 대응 작업**을 진행하였습니다
- HomeVC의 현재위치 조회 버튼 및 SearchVC의 키워드 검색 진행시 현재 위치 조회권한 검사코드 추가
- 조회권한 미획득시 사용자에게 Reet-Place 앱과 관련된 위치조회 권한 설정을 켤 수 있는 설정 창으로의 전환 팝업 추가

## 📋 변경 사항
### SearchPlaceAction Protocol
- 기존에 SearchVC.swith 파일 내에 있던 `SearchPlaceAction` 프로토콜 파일 분리
- SearchPlaceAction내의 정의되어있던 함수 유형 변경(위치 값 반환 → LocationManager 객체 반환)

### UIViewController+
- ViewController extension에 현재위치조회 권한과 관련된 설정 유도를 위한 릿플 팝업창 함수코드 추가
- `openReetPlaceSettings()` 를 통해 Reet-Place 앱과 관련된 권한설정 창 전환(아이폰 기본설정 앱 내부) 함수 추가

## 📋 (코드 리뷰 반영) 변경 사항
### 위치 권한 요청 문구 수정
- 태현님의 코멘트에 따라 위치권한 요청 문구를 수정하였습니다! (우선적으로 조치해 주셨던 문구로 수정을 진행하였습니다)
  - **변경문구**
  `원활한 지도 사용과 위치 기반 장소 검색을 위해 사용자의 위치 정보가 필요합니다.`

### KeychainManager의 Key 항목 추가
사용자가 현재위치 조회를 거부했을 경우 매번 앱을 실행할 때 네이버 지도의 기본 실행 위치인 네이버 사옥을 중심으로 '릿플 인기'가 조회되는 문제를 수정하기 위해 지도의 위치가 변경될 때마다 해당 지도의 중심좌표(위경도) 값을 Keychain 내부에 저장하는 로직을 추가하였습니다
- **추가된 항목**
`lastPositionLat, lastPositionLng`

### 최초 지도 진입 시 위치권한설정 확인
최초 홈 화면에서 지도에 진입한 경우 **기본적으로** 위치권한 상태를 확인하는 방식으로 구조를 변경하였습니다
- (홈화면 최초 진입시) 기본적인 위치권한 상태 확인
  - 현재위치조회 **`승인`** 상태일 경우 사용자의 현재 위치에 해당하는 '릿플인기' 항목조회
  - 현재위치조회 **`거절`** 상태일 경우 사용자가 가장 마지막에 사용했던 위치에 해당하는 '릿플인기' 항목조회
    - 최초 앱 실행의 경우 네이버 지도가 기본적으로 설정하는 분당구 정자동 네이버 사옥 위치로 설정(저장된 마지막 위치 없음)
  - 현재위치조회 **`미결정`** 상태일 경우 사용자에게 현재위치조회 권한을 요청하는 팝업창 생성
    - 이후 사용자가 위치조회권한을 설정한 경우, 위치조회 권한상태가 변경되면서 `locationManagerDidChangeAuthorization`가 호출 되어 위치권한설정에 따른 지도위치 이동 및 '릿플 인기' 항목조회

## 🔍 Code Review (코드 리뷰 이후 추가)
### 시뮬레이터
시뮬레이터 내부의 기본설정 앱에서 Reet-Place 항목 설정이 보이지 않는 문제가 있습니다(Setting.bundle 파일을 설정하라는 글 등을 살펴보았는데 우선 보류하였습니다) 앱 설정 전환 코드 `UIApplication.openSettingsURLString`의 실기기에서의 테스트(빨리 애플개발자 계정 권한문제를 해결해서 제 휴대폰에도 바로 설치 할 수 있는 작업을 진행해보도록 하겠습니다..) 확인이 필요 할 것 같습니다!

### (추가항목) 마지막 위치 저장
현재 `NMFMapViewCameraDelegate`에 구현되어 있는 **마지막 위치 저장 코드**에서 저장할 위치가 네이버 사옥일 경우에는 저장을 진행하고 있지 않습니다. 네이버 지도는 기본적으로 마지막 위치를 기억하는 기능이 없는 것 같습니다..(맞을려나요ㅠ) 그래서 그런지 매번 지도를 불러올 때마다 네이버 사옥으로 우선 이동하게 되어 키체인에 마지막 위치가 (사실상)초기화 되어버리는 문제가 있었습니다. 그래서 우선적으로 네이버 사옥의 절대 위경도 값을 입력하고 조건문을 통해 제어하는 방식으로 다소 무식한(?) 방법을 사용하게 되었습니다. 이와 관련해서 우려되는 부분이나 다른 의견이 있으시면 코멘트 부탁드립니다 🙇🏻

## 📸 ScreenShot (코멘트 반영)
<img src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/26570294/4b6b7c69-3624-4ff6-af15-44531a3b3b8b" width="250px" />
<img src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/26570294/565deed6-dfb1-4d6a-84db-9cc4aae44ace" width="250px" />
<img src="https://github.com/dnd-side-project/dnd-8th-2-frontend/assets/26570294/661294f8-dbb5-426c-90a2-d3ad2eb9dd17" width="250px" />

### 연결된 이슈 Close
close #122 
