### PR TITLE
Chore/#131 북마크 종류 별 정보 조회 API 에러 임시 대응

### DIFF
--- a/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
+++ b/Reet-Place/Reet-Place.xcodeproj/project.pbxproj
@@ -1748,7 +1748,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Reet-Place/Reet-PlaceDebug.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = C9U8778A7W;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1790,7 +1790,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Reet-Place/Reet-PlaceRelease.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = C9U8778A7W;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Reet-Place/Reet-Place/Screen/BookMark/Cell/BookmarkTypeCVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/Cell/BookmarkTypeCVC.swift
@@ -80,14 +80,14 @@ class BookmarkTypeCVC: BaseCollectionViewCell {
             break
         }
         
-        countLabel.text = String(typeInfo.cnt)
+        // TODO: - 북마크 종류 별 정보 조회 API 수정 시 복구
+        // countLabel.text = String(typeInfo.cnt)
+        countLabel.isHidden = true
         
         // 북마크가 없으면 기본 이미지 노출
         if typeInfo.cnt > 0 {
             thumbnailImageView.contentMode = .scaleAspectFill
             thumbnailImageView.layer.borderWidth = 0.0
-            
-            // TODO: - UIImageView+의 setImage 함수 placeholder 파라미터 추가 됨 (임시 코드 - UIImage() 삽입)
             thumbnailImageView.setImage(with: typeInfo.thumbnailUrlString)
         } else {
             thumbnailImageView.contentMode = .scaleAspectFit

--- a/Reet-Place/Reet-Place/Screen/BookMark/View/AllBookmarkButton.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/View/AllBookmarkButton.swift
@@ -86,7 +86,9 @@ class AllBookmarkButton: UIButton {
             stackView.addArrangedSubview($0)
         }
 
-        countLabel.text = String(count)
+        // TODO: - 북마크 종류 별 정보 조회 API 수정 시 복구
+        // countLabel.text = String(count)
+        countLabel.isHidden = true
         
         rightImageView.snp.makeConstraints {
             $0.width.equalTo(rightImageView.snp.height)

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkVC.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewController/BookmarkVC.swift
@@ -51,9 +51,6 @@ final class BookmarkVC: BaseNavigationViewController {
     }
     
     private let viewModel = BookmarkVM()
-        
-    private var wishListInfo: TypeInfo?
-    private var historyInfo: TypeInfo?
     
     
     // MARK: - Life Cycle
@@ -244,8 +241,6 @@ extension BookmarkVC {
         viewModel.output.BookmarkWishlistInfo
             .withUnretained(self)
             .subscribe(onNext: { owner, data in
-                owner.wishListInfo = data
-                
                 DispatchQueue.main.async {
                     owner.bookmarkTypeCV.reloadData()
                 }
@@ -256,8 +251,6 @@ extension BookmarkVC {
         viewModel.output.BookmarkHistoryInfo
             .withUnretained(self)
             .subscribe(onNext: { owner, data in
-                owner.historyInfo = data
-                
                 DispatchQueue.main.async {
                     owner.bookmarkTypeCV.reloadData()
                 }
@@ -306,15 +299,12 @@ extension BookmarkVC: UICollectionViewDelegate {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let wishListInfo = wishListInfo,
-              let historyInfo = historyInfo else { return }
-        
         var bookmarkSearchType: BookmarkSearchType = .want
         
         if indexPath.row == 0 {
-            guard wishListInfo.cnt != 0 else { return }
+            guard viewModel.output.BookmarkWishlistInfo.value.cnt != 0 else { return }
         } else {
-            guard historyInfo.cnt != 0 else { return }
+            guard viewModel.output.BookmarkHistoryInfo.value.cnt != 0 else { return }
             bookmarkSearchType = .done
         }
         
@@ -330,16 +320,12 @@ extension BookmarkVC: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BookmarkTypeCVC.className, for: indexPath) as? BookmarkTypeCVC else { return UICollectionViewCell() }
-        
-        guard let wishListInfo = wishListInfo,
-              let historyInfo = historyInfo else { return cell }
-        
         if indexPath.row == 0 {
-            cell.configureData(typeInfo: wishListInfo)
+            cell.configureData(typeInfo: viewModel.output.BookmarkWishlistInfo.value)
         }
         
         if indexPath.row == 1 {
-            cell.configureData(typeInfo: historyInfo)
+            cell.configureData(typeInfo: viewModel.output.BookmarkHistoryInfo.value)
         }
         
         return cell

--- a/Reet-Place/Reet-Place/Screen/BookMark/ViewModel/BookmarkVM.swift
+++ b/Reet-Place/Reet-Place/Screen/BookMark/ViewModel/BookmarkVM.swift
@@ -33,9 +33,9 @@ final class BookmarkVM: BaseViewModel {
         
         var BookmarkAllCnt = BehaviorRelay<Int>(value: 0)
         
-        var BookmarkWishlistInfo = PublishRelay<TypeInfo>()
+        var BookmarkWishlistInfo = BehaviorRelay<TypeInfo>(value: .init(type: "WANT", cnt: 0, thumbnailUrlString: ""))
         
-        var BookmarkHistoryInfo = PublishRelay<TypeInfo>()
+        var BookmarkHistoryInfo = BehaviorRelay<TypeInfo>(value: .init(type: "GONE", cnt: 0, thumbnailUrlString: ""))
     }
     
     init() {
@@ -69,13 +69,17 @@ extension BookmarkVM: Output {
 extension BookmarkVM {
     
     func getBookmarkMock() {
-        BookmarkMainModel.getMock { [weak self] data in
-            guard let self = self else { return }
-            
-            self.output.BookmarkAllCnt.accept(data.bookmarkMainInfo[0].cnt + data.bookmarkMainInfo[1].cnt)
-            self.output.BookmarkWishlistInfo.accept(data.bookmarkMainInfo[0])
-            self.output.BookmarkHistoryInfo.accept(data.bookmarkMainInfo[1])
-        }
+//        BookmarkMainModel.getMock { [weak self] data in
+//            guard let self = self else { return }
+//            
+//            self.output.BookmarkAllCnt.accept(data.bookmarkMainInfo[0].cnt + data.bookmarkMainInfo[1].cnt)
+//            self.output.BookmarkWishlistInfo.accept(data.bookmarkMainInfo[0])
+//            self.output.BookmarkHistoryInfo.accept(data.bookmarkMainInfo[1])
+//        }
+//        
+        // TODO: - 북마크 종류 별 정보 조회 API 수정 시 복구
+        getBookmarkList(type: .want)
+        getBookmarkList(type: .done)
     }
     
     /// 서버에 북마크 개수 요청
@@ -104,4 +108,37 @@ extension BookmarkVM {
             .disposed(by: bag)
     }
     
+    // TODO: - 북마크 종류 별 정보 조회 API 수정 시 제거
+    /// 가고싶어요, 다녀왔어요 북마크를 1 페이지 씩 조회해 존재 여부 확인
+    func getBookmarkList(type: BookmarkSearchType) {
+        let page = 0
+        let path = "/api/bookmarks?searchType=\(type.rawValue)&page=\(page)&size=10&sort=LATEST"
+        let resource = URLResource<BookmarkListResponseModel>(path: path)
+        
+        apiSession.requestGet(urlResource: resource)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, result in
+                switch result {
+                case .success(let data):
+                    let isExist: Bool = !data.content.isEmpty
+                    
+                    if type == .want {
+                        if isExist { owner.output.BookmarkAllCnt.accept(100) }
+                        owner.output.BookmarkWishlistInfo
+                            .accept(.init(type: "WANT",
+                                          cnt: isExist ? 100 : 0,
+                                          thumbnailUrlString: "https://picsum.photos/600/400"))
+                    } else if type == .done {
+                        if isExist { owner.output.BookmarkAllCnt.accept(100) }
+                        owner.output.BookmarkHistoryInfo
+                            .accept(.init(type: "GONE",
+                                          cnt: isExist ? 100 : 0,
+                                          thumbnailUrlString: "https://picsum.photos/600/300"))
+                    }
+                case .failure(let error):
+                    owner.apiError.onNext(error)
+                }
+            })
+            .disposed(by: bag)
+    }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약 
- 북마크 종류 별 정보 조회 API 에러 임시 대응

## 📋 변경 사항
### 북마크 탭 노출 방식 변경
- 가고싶어요, 다녀왔어요 북마크를 1페이지씩 조회해서 존재 여부만 판단할 수 있도록 처리해두었습니다!
- 기존에는 썸네일 + 각 북마크의 개수를 노출해야하는데, 현재는 (해당 북마크가 있을 시) 임시 이미지 노출, 개수는 노출하지 않도록 했습니다.

## 🔍 Code Review
N/A

